### PR TITLE
Add BoxedError type alias

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,4 @@
+use std::error::Error;
+
+/// Alias for boxed errors that can be sent across threads.
+pub type BoxedError = Box<dyn Error + Send + Sync>;

--- a/src/layers/attention/mod.rs
+++ b/src/layers/attention/mod.rs
@@ -1,5 +1,3 @@
-use std::error::Error;
-
 use candle_core::Tensor;
 
 mod mask;
@@ -13,6 +11,8 @@ pub use alibi::{AttentionLinearBiases, AttentionLinearBiasesError};
 
 mod self_attention;
 pub use self_attention::{QkvMode, SelfAttention, SelfAttentionError};
+
+use crate::error::BoxedError;
 
 /// Trait implemented by modules that perform attention scoring.
 pub trait AttentionScorer {
@@ -39,5 +39,5 @@ pub trait AttentionScorer {
         value: &Tensor,
         attention_mask: &AttentionMask,
         train: bool,
-    ) -> Result<Tensor, Box<dyn Error + Send + Sync>>;
+    ) -> Result<Tensor, BoxedError>;
 }

--- a/src/layers/attention/sdpa.rs
+++ b/src/layers/attention/sdpa.rs
@@ -1,10 +1,9 @@
-use std::error::Error;
-
 use candle_core::Tensor;
 use candle_nn::ops::softmax;
 use candle_nn::Dropout;
 use snafu::{ResultExt, Snafu};
 
+use crate::error::BoxedError;
 use crate::layers::attention::{
     AttentionLinearBiases, AttentionLinearBiasesError, AttentionMask, AttentionMaskError,
     AttentionScorer,
@@ -58,7 +57,7 @@ impl AttentionScorer for ScaledDotProductAttention {
         value: &Tensor,
         attention_mask: &AttentionMask,
         train: bool,
-    ) -> Result<Tensor, Box<dyn Error + Send + Sync>> {
+    ) -> Result<Tensor, BoxedError> {
         // TODO: add code path for flash attention, but verify the attention
         //       layer is working first...
 

--- a/src/layers/attention/self_attention.rs
+++ b/src/layers/attention/self_attention.rs
@@ -1,10 +1,10 @@
 use std::borrow::Cow;
-use std::error::Error;
 
 use candle_core::{IndexOp, Module, ModuleT, Tensor};
 use candle_nn::{linear, Dropout, Linear, VarBuilder};
 use snafu::{ResultExt, Snafu};
 
+use crate::error::BoxedError;
 use crate::layers::attention::{
     AttentionMask, AttentionMaskError, AttentionScorer, ScaledDotProductAttentionError,
 };
@@ -52,9 +52,7 @@ pub enum QkvTensors {
 #[derive(Debug, Snafu)]
 pub enum SelfAttentionError {
     #[snafu(display("Cannot apply attention scorer"))]
-    AttentionScorer {
-        source: Box<dyn Error + Send + Sync>,
-    },
+    AttentionScorer { source: BoxedError },
 
     #[snafu(display("Cannot create causal mask"))]
     CausalMask { source: candle_core::Error },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod error;
 mod kv_cache;
 pub mod layers;
 pub mod util;


### PR DESCRIPTION
This is an alias for `Box<dyn Error + Send + Sync>`.

We are going to have a lot of these with the layer refactors, introduce the alias in `main` already.