### PR TITLE
Convert all the existing layers to use the builder pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ homepage = "https://github.com/danieldk/oxidized-transformers"
 [dependencies]
 candle-core =  { git = "https://github.com/huggingface/candle.git", rev = "a90fc5c" }
 candle-nn = { git = "https://github.com/huggingface/candle.git", rev = "a90fc5c" }
+serde = "1"
 snafu = "0.8"

--- a/src/architectures/decoder.rs
+++ b/src/architectures/decoder.rs
@@ -1,0 +1,84 @@
+use std::fmt::Debug;
+
+use candle_core::Tensor;
+use candle_nn::VarBuilder;
+
+use crate::architectures::output::LayerOutputs;
+use crate::error::BoxedError;
+use crate::layers::attention::AttentionMask;
+
+/// Decoder output.
+pub struct DecoderOutput<C> {
+    all_outputs: Vec<Tensor>,
+    cache: Option<Vec<C>>,
+}
+
+impl<C> DecoderOutput<C> {
+    pub fn new(all_outputs: Vec<Tensor>, cache: Option<Vec<C>>) -> Self {
+        Self { all_outputs, cache }
+    }
+
+    pub fn cache(&self) -> Option<&[C]> {
+        self.cache.as_deref()
+    }
+}
+
+impl<C> LayerOutputs for DecoderOutput<C> {
+    fn layer_outputs(&self) -> &[Tensor] {
+        &self.all_outputs
+    }
+
+    fn embedding_layer_output(&self) -> Option<&Tensor> {
+        self.all_outputs.first()
+    }
+}
+
+/// Trait for decoder layers.
+pub trait DecoderLayer {
+    /// Cache type for the decoder.
+    ///
+    /// The cache can store the intermediate values of the decoder layer,
+    /// avoiding recomputation when calling the decoder again for generating
+    /// another output.
+    type Cache;
+
+    /// Apply the decoder layer to the given hidden representations.
+    ///
+    /// * `piece_ids` - Hidden representations to apply the layer to.
+    ///   *Shape:* `(batch_size, seq_len, width)`
+    /// * `attention_mask` - Attention mask. Sequence elements for which the
+    ///    corresponding mask element is set to `false` are ignored
+    ///    during attention calculation.
+    ///   *Shape:* `(batch_size, seq_len)`
+    /// * `cache` - Cache to avoid recomputing intermediate values.
+    /// * `positions` - Input positions.
+    ///    *Shape:* `(batch_size, seq_len)`
+    /// * `train` - Whether to train the layer.
+    ///
+    /// Returns layer output and the cache.
+    /// *Shape:* ``(batch_size, seq_len, width)``
+    fn forward_t(
+        &self,
+        piece_ids: &Tensor,
+        attention_mask: &AttentionMask,
+        cache: Option<&Self::Cache>,
+        positions: Option<&Tensor>,
+        train: bool,
+    ) -> Result<(Tensor, Option<Self::Cache>), BoxedError>;
+}
+
+/// Trait for building decoder layers.
+pub trait BuildDecoderLayer: Debug {
+    /// Cache type for the decoder.
+    ///
+    /// The cache can store the intermediate values of the decoder layer,
+    /// avoiding recomputation when calling the decoder again for generating
+    /// another output.
+    type Cache;
+
+    /// Build a decoder layer.
+    fn build_decoder_layer(
+        &self,
+        vb: VarBuilder,
+    ) -> Result<Box<dyn DecoderLayer<Cache = Self::Cache>>, BoxedError>;
+}

--- a/src/architectures/encoder.rs
+++ b/src/architectures/encoder.rs
@@ -1,0 +1,60 @@
+use std::fmt::Debug;
+
+use candle_core::Tensor;
+use candle_nn::VarBuilder;
+
+use crate::architectures::output::LayerOutputs;
+use crate::error::BoxedError;
+use crate::layers::attention::AttentionMask;
+
+/// Encoder output.
+pub struct EncoderOutput {
+    all_outputs: Vec<Tensor>,
+}
+
+impl EncoderOutput {
+    pub fn new(all_outputs: Vec<Tensor>) -> Self {
+        Self { all_outputs }
+    }
+}
+
+impl LayerOutputs for EncoderOutput {
+    fn layer_outputs(&self) -> &[Tensor] {
+        &self.all_outputs
+    }
+
+    fn embedding_layer_output(&self) -> Option<&Tensor> {
+        self.all_outputs.first()
+    }
+}
+
+/// Trait for encoder layers.
+pub trait EncoderLayer {
+    /// Apply the encoder layer to the given hidden representations.
+    ///
+    /// * `piece_ids` - Hidden representations to apply the layer to.
+    ///   *Shape:* `(batch_size, seq_len, width)`
+    /// * `attention_mask` - Attention mask. Sequence elements for which the
+    ///    corresponding mask element is set to `false` are ignored
+    ///    during attention calculation.
+    ///   *Shape:* `(batch_size, seq_len)`
+    /// * `positions` - Input positions.
+    ///    *Shape:* `(batch_size, seq_len)`
+    /// * `train` - Whether to train the layer.
+    ///
+    /// Returns layer output and the cache.
+    /// *Shape:* ``(batch_size, seq_len, width)``
+    fn forward_t(
+        &self,
+        piece_ids: &Tensor,
+        attention_mask: &AttentionMask,
+        positions: Option<&Tensor>,
+        train: bool,
+    ) -> Result<Tensor, BoxedError>;
+}
+
+/// Trait for building encoder layers.
+pub trait BuildEncoderLayer: Debug {
+    /// Build a encoder layer.
+    fn build_encoder_layer(&self, vb: VarBuilder) -> Result<Box<dyn EncoderLayer>, BoxedError>;
+}

--- a/src/architectures/mod.rs
+++ b/src/architectures/mod.rs
@@ -1,0 +1,9 @@
+/// Traits for model architectures.
+mod decoder;
+pub use decoder::{BuildDecoderLayer, DecoderLayer, DecoderOutput};
+
+mod encoder;
+pub use encoder::{BuildEncoderLayer, EncoderLayer, EncoderOutput};
+
+mod output;
+pub use output::LayerOutputs;

--- a/src/architectures/output.rs
+++ b/src/architectures/output.rs
@@ -1,0 +1,10 @@
+use candle_core::Tensor;
+
+/// Trait for querying layer outputs of a model.
+pub trait LayerOutputs {
+    /// Outputs of all layers.
+    fn layer_outputs(&self) -> &[Tensor];
+
+    /// Output of the embedding layer.
+    fn embedding_layer_output(&self) -> Option<&Tensor>;
+}

--- a/src/layers/activation.rs
+++ b/src/layers/activation.rs
@@ -1,0 +1,38 @@
+use candle_core::ModuleT;
+use candle_nn::{Activation as CandleActivation, VarBuilder};
+use serde::{Deserialize, Serialize};
+
+use crate::error::BoxedError;
+use crate::layers::build_module::BuildModule;
+
+/// Activation functions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "lowercase")]
+pub enum Activation {
+    /// Gausian Error Linear Unit.
+    ///
+    /// See [Hendrycks and Gimpel, 2016](https://arxiv.org/abs/1606.08415).
+    GELU,
+
+    /// Rectified Linear Unit.
+    ///
+    /// See [Fukushima, 1969](https://ieeexplore.ieee.org/document/4082265).
+    ReLU,
+
+    /// Sigmoid Linear Unit.
+    ///
+    /// See [Hendrycks and Gimpel, 2016](https://arxiv.org/abs/1606.08415).
+    SiLU,
+}
+
+impl BuildModule for Activation {
+    fn build(&self, _vb: VarBuilder) -> Result<Box<dyn ModuleT>, BoxedError> {
+        use Activation::*;
+        Ok(match self {
+            GELU => Box::new(CandleActivation::Gelu),
+            ReLU => Box::new(CandleActivation::Relu),
+            SiLU => Box::new(CandleActivation::Silu),
+        })
+    }
+}

--- a/src/layers/attention/mask.rs
+++ b/src/layers/attention/mask.rs
@@ -9,6 +9,9 @@ pub enum AttentionMaskError {
 
     #[snafu(display("Cannot intersect masks"))]
     IntersectMasks { source: candle_core::Error },
+
+    #[snafu(display("Cannot reshape 2D mask to 4D"))]
+    ReshapeMask { source: candle_core::Error },
 }
 
 /// Attention mask.
@@ -25,8 +28,15 @@ impl AttentionMask {
     ///
     /// * `bool_mask` - Boolean mask tensor.
     ///   *Shape:* `(batch_size, seq_len)`
-    pub fn new(bool_mask: Tensor) -> Self {
-        AttentionMask { bool_mask }
+    pub fn new(bool_mask: Tensor) -> Result<Self, AttentionMaskError> {
+        let bool_mask = match bool_mask.shape().dims2() {
+            Ok((batch_len, key_len)) => bool_mask
+                .reshape((batch_len, 1, 1, key_len))
+                .context(ReshapeMaskSnafu)?,
+            _ => bool_mask,
+        };
+
+        Ok(AttentionMask { bool_mask })
     }
 
     /// Use the attention mask to mask attention logits.
@@ -38,16 +48,22 @@ impl AttentionMask {
     pub fn apply_logit_mask(&self, input: &Tensor) -> Result<Tensor, AttentionMaskError> {
         // Underflows to -inf for more narrow floating point types, which
         // is ok for masking.
-        let blocked_value = Tensor::try_from(f32::MIN).context(ApplyLogitsMaskSnafu)?;
+        let blocked_value = Tensor::try_from(f32::MIN)
+            .and_then(|xs| xs.broadcast_as(input.shape()))
+            .context(ApplyLogitsMaskSnafu)?;
         self.bool_mask
-            .where_cond(input, &blocked_value)
+            .broadcast_as(input.shape())
+            .and_then(|xs| xs.where_cond(input, &blocked_value))
             .context(ApplyLogitsMaskSnafu)
     }
 
     /// Merge this attention mask with another attention mask.
     pub fn intersect(&self, other: &AttentionMask) -> Result<AttentionMask, AttentionMaskError> {
         Ok(AttentionMask {
-            bool_mask: (&self.bool_mask * &other.bool_mask).context(IntersectMasksSnafu)?,
+            bool_mask: self
+                .bool_mask
+                .broadcast_mul(&other.bool_mask)
+                .context(IntersectMasksSnafu)?,
         })
     }
 }

--- a/src/layers/attention/mod.rs
+++ b/src/layers/attention/mod.rs
@@ -1,18 +1,54 @@
+use std::fmt::Debug;
+
 use candle_core::Tensor;
+use candle_nn::VarBuilder;
 
 mod mask;
 pub use mask::{AttentionMask, AttentionMaskError};
 
 mod sdpa;
-pub use sdpa::{ScaledDotProductAttention, ScaledDotProductAttentionError};
+pub use sdpa::{
+    ScaledDotProductAttention, ScaledDotProductAttentionConfig, ScaledDotProductAttentionError,
+};
 
 mod alibi;
-pub use alibi::{AttentionLinearBiases, AttentionLinearBiasesError};
+pub use alibi::{AttentionLinearBiases, AttentionLinearBiasesConfig, AttentionLinearBiasesError};
 
 mod self_attention;
-pub use self_attention::{QkvMode, SelfAttention, SelfAttentionError};
+pub use self_attention::{
+    AttentionHeads, QkvMode, QkvSplit, SelfAttention, SelfAttentionConfig, SelfAttentionError,
+};
 
 use crate::error::BoxedError;
+
+/// Trait for attention modules.
+pub trait Attention {
+    /// Apply attention to the given input.
+    ///
+    /// * `input` - Input tensor.
+    ///   *Shape:* `(batch_size, seq_len, width)`
+    /// * `attention_mask` - Attention mask. Sequence elements for which
+    ///   the corresponding mask element is set to `false` are ignored in attention.
+    /// * `train` - Whether the model is trained.
+    /// * `use_causal_mask` - Whether to use a causal mask.
+    ///
+    /// Returns: Hidden representations after attention.
+    fn forward_t(
+        &self,
+        input: &Tensor,
+        attention_mask: &AttentionMask,
+        train: bool,
+        use_causal_mask: bool,
+    ) -> Result<Tensor, BoxedError>;
+}
+
+/// Build an attention module.
+pub trait BuildAttention {
+    /// Build an attention module.
+    ///
+    /// * `vb` - Variable builder used for attention parameters.
+    fn build(&self, vb: VarBuilder) -> Result<Box<dyn Attention>, BoxedError>;
+}
 
 /// Trait implemented by modules that perform attention scoring.
 pub trait AttentionScorer {
@@ -40,4 +76,12 @@ pub trait AttentionScorer {
         attention_mask: &AttentionMask,
         train: bool,
     ) -> Result<Tensor, BoxedError>;
+}
+
+/// Build an attention scorer module.
+pub trait BuildAttentionScorer: Debug {
+    /// Build an attention module.
+    ///
+    /// * `vb` - Variable builder used for attention parameters.
+    fn build(&self, vb: VarBuilder) -> Result<Box<dyn AttentionScorer>, BoxedError>;
 }

--- a/src/layers/build_module.rs
+++ b/src/layers/build_module.rs
@@ -1,0 +1,12 @@
+use std::fmt::Debug;
+
+use candle_core::ModuleT;
+use candle_nn::VarBuilder;
+
+use crate::error::BoxedError;
+
+/// Traits for types that can build modules.
+pub trait BuildModule: Debug {
+    /// Build a module.
+    fn build(&self, vb: VarBuilder) -> Result<Box<dyn ModuleT>, BoxedError>;
+}

--- a/src/layers/dropout.rs
+++ b/src/layers/dropout.rs
@@ -1,0 +1,33 @@
+use candle_core::ModuleT;
+use candle_nn::{Dropout, VarBuilder};
+
+use crate::error::BoxedError;
+use crate::layers::build_module::BuildModule;
+
+/// Dropout configuration.
+#[derive(Clone, Debug)]
+pub struct DropoutConfig {
+    p: f32,
+}
+
+impl DropoutConfig {
+    /// Dropout probability.
+    ///
+    /// Default: `0.0`
+    pub fn p(mut self, p: f32) -> Self {
+        self.p = p;
+        self
+    }
+}
+
+impl Default for DropoutConfig {
+    fn default() -> Self {
+        Self { p: 0.0 }
+    }
+}
+
+impl BuildModule for DropoutConfig {
+    fn build(&self, _vb: VarBuilder) -> Result<Box<dyn ModuleT>, BoxedError> {
+        Ok(Box::new(Dropout::new(self.p)))
+    }
+}

--- a/src/layers/embeddings/mod.rs
+++ b/src/layers/embeddings/mod.rs
@@ -1,6 +1,8 @@
 /// Embedding layers.
 mod qk_rotary_embeddings;
-pub use qk_rotary_embeddings::{QueryKeyRotaryEmbeddings, QueryKeyRotaryEmbeddingsError};
+pub use qk_rotary_embeddings::{
+    QueryKeyRotaryEmbeddings, QueryKeyRotaryEmbeddingsConfig, QueryKeyRotaryEmbeddingsError,
+};
 
 mod rotary_embeddings;
-pub use rotary_embeddings::{RotaryEmbeddings, RotaryEmbeddingsError};
+pub use rotary_embeddings::{RotaryEmbeddings, RotaryEmbeddingsConfig, RotaryEmbeddingsError};

--- a/src/layers/identity.rs
+++ b/src/layers/identity.rs
@@ -1,6 +1,22 @@
-use candle_core::{Module, Tensor};
+use candle_core::{Module, ModuleT, Tensor};
+use candle_nn::VarBuilder;
 
+use crate::error::BoxedError;
+use crate::layers::build_module::BuildModule;
+
+/// Identity module.
+///
+/// This module passes through input as-is. It is especially useful in
+/// cases where a configurable module (such as dropout or normalization)
+/// needs to be stubbed with a module that does not do anything.
+#[derive(Clone, Debug)]
 pub struct Identity;
+
+impl BuildModule for Identity {
+    fn build(&self, _vb: VarBuilder) -> Result<Box<dyn ModuleT>, BoxedError> {
+        Ok(Box::new(Identity))
+    }
+}
 
 impl Module for Identity {
     fn forward(&self, xs: &Tensor) -> candle_core::Result<Tensor> {

--- a/src/layers/layer_norm.rs
+++ b/src/layers/layer_norm.rs
@@ -1,0 +1,115 @@
+use candle_core::ModuleT;
+use candle_nn::{layer_norm, rms_norm, LayerNormConfig as CandleLayerNormConfig, VarBuilder};
+
+use crate::error::BoxedError;
+use crate::layers::build_module::BuildModule;
+
+/// Layer norm configuration.
+#[derive(Clone, Debug)]
+pub struct LayerNormConfig {
+    pub affine: bool,
+    pub eps: f64,
+    pub remove_mean: bool,
+    pub size: usize,
+}
+
+impl LayerNormConfig {
+    /// Whether to use an affine transformation.
+    ///
+    /// Default: `true`
+    pub fn affine(mut self, affine: bool) -> Self {
+        self.affine = affine;
+        self
+    }
+
+    /// Epsilon value.
+    ///
+    /// Default: `1e-12`
+    pub fn eps(mut self, eps: f64) -> Self {
+        self.eps = eps;
+        self
+    }
+
+    /// Whether to remove the mean.
+    ///
+    /// If the mean is not removed, this layer is equivalent to `RMSNorm`.
+    ///
+    /// Default: `true`
+    pub fn remove_mean(mut self, remove_mean: bool) -> Self {
+        self.remove_mean = remove_mean;
+        self
+    }
+
+    /// Dimensionality of the layer.
+    ///
+    /// Default: `768`
+    pub fn size(mut self, size: usize) -> Self {
+        self.size = size;
+        self
+    }
+}
+
+impl Default for LayerNormConfig {
+    fn default() -> Self {
+        Self {
+            affine: true,
+            eps: 1e-12,
+            remove_mean: true,
+            size: 768,
+        }
+    }
+}
+
+impl BuildModule for LayerNormConfig {
+    fn build(&self, vb: VarBuilder) -> Result<Box<dyn ModuleT>, BoxedError> {
+        Ok(Box::new(layer_norm(
+            self.size,
+            CandleLayerNormConfig {
+                affine: self.affine,
+                eps: self.eps,
+                remove_mean: self.remove_mean,
+            },
+            vb,
+        )?))
+    }
+}
+
+/// RMS norm configuration.
+#[derive(Clone, Debug)]
+pub struct RMSNormConfig {
+    pub eps: f64,
+    pub size: usize,
+}
+
+impl RMSNormConfig {
+    /// Epsilon value.
+    ///
+    /// Default: `1e-12`
+    pub fn eps(mut self, eps: f64) -> Self {
+        self.eps = eps;
+        self
+    }
+
+    /// Dimensionality of the layer.
+    ///
+    /// Default: `768`
+    pub fn size(mut self, size: usize) -> Self {
+        self.size = size;
+        self
+    }
+}
+
+impl Default for RMSNormConfig {
+    fn default() -> Self {
+        Self {
+            eps: 1e-12,
+            size: 768,
+        }
+    }
+}
+
+impl BuildModule for RMSNormConfig {
+    fn build(&self, vb: VarBuilder) -> Result<Box<dyn ModuleT>, BoxedError> {
+        Ok(Box::new(rms_norm(self.size, self.eps, vb)?))
+    }
+}

--- a/src/layers/mod.rs
+++ b/src/layers/mod.rs
@@ -1,9 +1,17 @@
+pub mod activation;
+
 pub mod attention;
+
+pub mod dropout;
 
 pub mod embeddings;
 
 pub mod feedforward;
 
-mod identity;
+pub mod identity;
+
+pub mod build_module;
+
+pub mod layer_norm;
 
 pub mod transformer;

--- a/src/layers/transformer/embeddings.rs
+++ b/src/layers/transformer/embeddings.rs
@@ -1,49 +1,207 @@
+use crate::error::BoxedError;
 use candle_core::{Module, ModuleT, Tensor};
 use candle_nn::{embedding, Embedding, VarBuilder};
 use snafu::{ResultExt, Snafu};
 
+use crate::layers::build_module::BuildModule;
 use crate::layers::identity::Identity;
 
-/// Layer normalizations used in a transformer embedding layer.
-///
-/// By default, all the normalizations are disabled by setting the layer
-/// normalization to the `Identity` module. Therefore, only normalizations
-/// that are needed have to be set.
-pub struct EmbeddingLayerNorms {
-    /// Normalization of the embeddings.
-    pub embed_output_layer_norm: Box<dyn ModuleT>,
+/// Configuration for transformer embedding layer.
+#[derive(Debug)]
+pub struct TransformerEmbeddingsConfig {
+    /// Dropout to apply to the embeddings.
+    embedding_dropout: Box<dyn BuildModule>,
 
-    /// Normalization of the projection layer.
-    pub proj_output_layer_norm: Box<dyn ModuleT>,
+    /// Layer normalization to apply to the embeddings.
+    embedding_layer_norm: Box<dyn BuildModule>,
+
+    /// Width of the embeddings.
+    embedding_width: usize,
+
+    /// Width of the transformer.
+    ///
+    /// The embedding layer will use a projection if the hidden width is
+    /// not equal to the embedding width.
+    hidden_width: usize,
+
+    /// Number of position embeddings.
+    n_positions: Option<usize>,
+
+    /// Vocabulary size (number of embeddings).
+    n_pieces: usize,
+
+    /// Token type vocabulary size (number of token type embeddings).
+    n_types: Option<usize>,
+
+    /// Dropout to apply after embedding projection.
+    projection_dropout: Box<dyn BuildModule>,
+
+    /// Layer normalization to apply to the projection layer.
+    projection_layer_norm: Box<dyn BuildModule>,
 }
 
-impl Default for EmbeddingLayerNorms {
-    fn default() -> Self {
-        EmbeddingLayerNorms {
-            embed_output_layer_norm: Box::new(Identity),
-            proj_output_layer_norm: Box::new(Identity),
-        }
+impl TransformerEmbeddingsConfig {
+    pub fn build(
+        &self,
+        vb: VarBuilder,
+    ) -> Result<TransformerEmbeddings, TransformerEmbeddingsError> {
+        let piece_embeddings = embedding(
+            self.n_pieces,
+            self.embedding_width,
+            vb.push_prefix("piece_embeddings"),
+        )
+        .context(ConstructionSnafu)?;
+
+        let type_embeddings = self
+            .n_types
+            .map(|n_types| {
+                embedding(
+                    n_types,
+                    self.embedding_width,
+                    vb.push_prefix("type_embeddings"),
+                )
+            })
+            .transpose()
+            .context(ConstructionSnafu)?;
+
+        let position_embeddings = self
+            .n_positions
+            .map(|n_positions| {
+                embedding(
+                    n_positions,
+                    self.embedding_width,
+                    vb.push_prefix("position_embeddings"),
+                )
+            })
+            .transpose()
+            .context(ConstructionSnafu)?;
+
+        let projection = if self.embedding_width != self.hidden_width {
+            Some(
+                embedding(
+                    self.embedding_width,
+                    self.hidden_width,
+                    vb.push_prefix("projection"),
+                )
+                .context(ConstructionSnafu)?,
+            )
+        } else {
+            None
+        };
+
+        Ok(TransformerEmbeddings {
+            embedding_dropout: self
+                .embedding_dropout
+                .build(vb.push_prefix("embedding_dropout"))
+                .context(BuildDropoutSnafu)?,
+            embedding_layer_norm: self
+                .embedding_layer_norm
+                .build(vb.push_prefix("embedding_layer_norm"))
+                .context(BuildLayerNormSnafu)?,
+            piece_embeddings,
+            position_embeddings,
+            projection,
+            projection_dropout: self
+                .projection_dropout
+                .build(vb.push_prefix("projection_dropout"))
+                .context(BuildDropoutSnafu)?,
+            projection_layer_norm: self
+                .projection_layer_norm
+                .build(vb.push_prefix("projection_layer_norm"))
+                .context(BuildLayerNormSnafu)?,
+
+            type_embeddings,
+        })
+    }
+
+    /// Dropout to apply to the embeddings.
+    ///
+    /// Default: `Identity`.
+    pub fn embedding_dropout(mut self, embedding_dropout: Box<dyn BuildModule>) -> Self {
+        self.embedding_dropout = embedding_dropout;
+        self
+    }
+
+    /// Layer normalization to apply to the embeddings.
+    ///
+    /// Default: `Identity`.
+    pub fn embedding_layer_norm(mut self, embedding_layer_norm: Box<dyn BuildModule>) -> Self {
+        self.embedding_layer_norm = embedding_layer_norm;
+        self
+    }
+
+    /// Width of the embeddings.
+    ///
+    /// Default: `768`.
+    pub fn embedding_width(mut self, embedding_width: usize) -> Self {
+        self.embedding_width = embedding_width;
+        self
+    }
+
+    /// Width of the transformer.
+    ///
+    /// The embedding layer will use a projection if the hidden width is
+    /// not equal to the embedding width.
+    ///
+    /// Default: `768`.
+    pub fn hidden_width(mut self, hidden_width: usize) -> Self {
+        self.hidden_width = hidden_width;
+        self
+    }
+
+    /// Number of position embeddings.
+    ///
+    /// Default: `None`.
+    pub fn n_positions(mut self, n_positions: Option<usize>) -> Self {
+        self.n_positions = n_positions;
+        self
+    }
+
+    /// Vocabulary size (number of embeddings).
+    ///
+    /// Default: `30000`.
+    pub fn n_pieces(mut self, n_pieces: usize) -> Self {
+        self.n_pieces = n_pieces;
+        self
+    }
+
+    /// Token type vocabulary size (number of token type embeddings).
+    ///
+    /// Default: `None`.
+    pub fn n_types(mut self, n_types: Option<usize>) -> Self {
+        self.n_types = n_types;
+        self
+    }
+
+    /// Dropout to apply after embedding projection.
+    ///
+    /// Default: `Identity`.
+    pub fn projection_dropout(mut self, projection_dropout: Box<dyn BuildModule>) -> Self {
+        self.projection_dropout = projection_dropout;
+        self
+    }
+
+    /// Layer normalization to apply to the projection layer.
+    ///
+    /// Default: `Identity`.
+    pub fn projection_layer_norm(mut self, projection_layer_norm: Box<dyn BuildModule>) -> Self {
+        self.projection_layer_norm = projection_layer_norm;
+        self
     }
 }
 
-/// Dropouts used in a transformer embedding layer.
-///
-/// By default, all the dropouts are disabled by setting the dropout
-/// to the `Identity` module. Therefore, only dropouts that are needed have
-/// to be set.
-pub struct EmbeddingLayerDropouts {
-    /// Dropout of the embeddings.
-    embed_output_layer_dropout: Box<dyn ModuleT>,
-
-    /// Dropout of the projection layer.
-    proj_output_layer_dropout: Box<dyn ModuleT>,
-}
-
-impl Default for EmbeddingLayerDropouts {
+impl Default for TransformerEmbeddingsConfig {
     fn default() -> Self {
-        EmbeddingLayerDropouts {
-            embed_output_layer_dropout: Box::new(Identity),
-            proj_output_layer_dropout: Box::new(Identity),
+        Self {
+            embedding_dropout: Box::new(Identity),
+            embedding_layer_norm: Box::new(Identity),
+            embedding_width: 768,
+            hidden_width: 768,
+            n_positions: None,
+            n_pieces: 30000,
+            n_types: None,
+            projection_dropout: Box::new(Identity),
+            projection_layer_norm: Box::new(Identity),
         }
     }
 }
@@ -51,6 +209,12 @@ impl Default for EmbeddingLayerDropouts {
 /// Errors for transformer embeddings.
 #[derive(Debug, Snafu)]
 pub enum TransformerEmbeddingsError {
+    #[snafu(display("Cannot build dropout"))]
+    BuildDropout { source: BoxedError },
+
+    #[snafu(display("Cannot build layer norm"))]
+    BuildLayerNorm { source: BoxedError },
+
     #[snafu(display("Cannot construct embeddings layer"))]
     Construction { source: candle_core::Error },
 
@@ -76,69 +240,17 @@ pub enum TransformerEmbeddingsError {
 /// embeddings and can optionally have position embeddings, type embeddings,
 /// and a projection of embeddings to the model's hidden size.
 pub struct TransformerEmbeddings {
+    embedding_dropout: Box<dyn ModuleT>,
+    embedding_layer_norm: Box<dyn ModuleT>,
     piece_embeddings: Embedding,
     type_embeddings: Option<Embedding>,
     position_embeddings: Option<Embedding>,
     projection: Option<Embedding>,
-    dropouts: EmbeddingLayerDropouts,
-    layer_norms: EmbeddingLayerNorms,
+    projection_dropout: Box<dyn ModuleT>,
+    projection_layer_norm: Box<dyn ModuleT>,
 }
 
 impl TransformerEmbeddings {
-    /// Construct an embeddings layer.
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        vb: VarBuilder,
-        dropouts: EmbeddingLayerDropouts,
-        embedding_width: usize,
-        hidden_width: usize,
-        layer_norms: EmbeddingLayerNorms,
-        n_pieces: usize,
-        n_positions: Option<usize>,
-        n_types: Option<usize>,
-    ) -> Result<Self, TransformerEmbeddingsError> {
-        let piece_embeddings = embedding(
-            n_pieces,
-            embedding_width,
-            vb.push_prefix("piece_embeddings"),
-        )
-        .context(ConstructionSnafu)?;
-
-        let type_embeddings = n_types
-            .map(|n_types| embedding(n_types, embedding_width, vb.push_prefix("type_embeddings")))
-            .transpose()
-            .context(ConstructionSnafu)?;
-
-        let position_embeddings = n_positions
-            .map(|n_positions| {
-                embedding(
-                    n_positions,
-                    embedding_width,
-                    vb.push_prefix("position_embeddings"),
-                )
-            })
-            .transpose()
-            .context(ConstructionSnafu)?;
-
-        let projection = if embedding_width != hidden_width {
-            Some(
-                embedding(embedding_width, hidden_width, vb.push_prefix("projection"))
-                    .context(ConstructionSnafu)?,
-            )
-        } else {
-            None
-        };
-
-        Ok(TransformerEmbeddings {
-            dropouts,
-            layer_norms,
-            piece_embeddings,
-            position_embeddings,
-            projection,
-            type_embeddings,
-        })
-    }
-
     /// Get position identifiers _[0..seq_len)_.
     fn get_positions(x: &Tensor) -> Result<Tensor, TransformerEmbeddingsError> {
         let (_, seq_len) = x.shape().dims2().context(PositionEmbeddingsSnafu)?;
@@ -187,29 +299,16 @@ impl TransformerEmbeddings {
         }
 
         embeddings = self
-            .layer_norms
-            .embed_output_layer_norm
+            .embedding_layer_norm
             .forward_t(&embeddings, train)
-            .and_then(|xs| {
-                self.dropouts
-                    .embed_output_layer_dropout
-                    .forward_t(&xs, train)
-            })
+            .and_then(|xs| self.embedding_dropout.forward_t(&xs, train))
             .context(NormalizeDropoutSnafu)?;
 
         if let Some(projection) = &self.projection {
             embeddings = projection
                 .forward(&embeddings)
-                .and_then(|xs| {
-                    self.layer_norms
-                        .proj_output_layer_norm
-                        .forward_t(&xs, train)
-                })
-                .and_then(|xs| {
-                    self.dropouts
-                        .proj_output_layer_dropout
-                        .forward_t(&xs, train)
-                })
+                .and_then(|xs| self.projection_layer_norm.forward_t(&xs, train))
+                .and_then(|xs| self.projection_dropout.forward_t(&xs, train))
                 .context(ProjectionSnafu)?;
         }
 

--- a/src/layers/transformer/mod.rs
+++ b/src/layers/transformer/mod.rs
@@ -1,6 +1,10 @@
 /// Transformer building blocks.
 mod embeddings;
-pub use embeddings::{EmbeddingLayerDropouts, EmbeddingLayerNorms, TransformerEmbeddings};
+pub use embeddings::{
+    TransformerEmbeddings, TransformerEmbeddingsConfig, TransformerEmbeddingsError,
+};
 
 mod layer;
-pub use layer::{DecoderLayer, EncoderLayer};
+pub use layer::{
+    TransformerDecoderLayer, TransformerEncoderLayer, TransformerLayerConfig, TransformerLayerError,
+};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
+pub mod architectures;
 pub mod error;
-mod kv_cache;
+pub mod kv_cache;
 pub mod layers;
 pub mod util;


### PR DESCRIPTION
We have two important design desiderata:

1. We want layers in models to be configurable, so that it is possible to make custom architectures using composition.

This was largely archieved in Curated Transformers by letting modules take other modules in the constructor parameters. However in Oxidized Transformers, this solution conflicts with:

2. Layers must construct their childeren, to have control over their namespacing.

In Curated Transformers, we could rely on PyTorch' module abstraction for namespacing. However, this does not work in Candle, since we have to provide a layer's prefix when constructing it.

So, instead we settle on a design that uses builders. Rather than directly building models, we build configuration structures (though they could also be called uninstantiated model graphs). Each configuration struct has a build method to create the corresponding module. This fulfills the second desideratum by letting a module build method also construct it's children by calling their build methods.

We fulfill the first desideratum by having each configuration take its childern as a type-generic boxed struct. For instance, the self-attention struct can have a generic layer norm in this way:

```rust
pub struct SelfAttentionConfig {
  layer_norm: Box<dyn BuildModule>,

  // ...
}
```

Any kind of layer configuration can be plugged in as the layer norm, as long as it implements the `BuildModule` trait.

This change updates all the existing layers to this pattern. After this change, each layer is generaly implemented as:

- A layer configuration struct.
- A `Default` implementation for the configuration.
- Setting methods following the builder pattern: allows named setting, but in contrast to public struct members, we can modify the struct fields.
- An implementation of the `BuildModule` trait, or a similar trait if it does not fit the signature of `BuildModule`
- A layer struct.
- Implementation of `ModuleT` or another trait.

Not all the layers have all of these parts. E.g. the rotary embeddings layers are not fully generic. Since they are strongly bound to the self-attention implementation, we don't expect downstream users to plug different implementations. Or in the case of embeddings, I still need to think about the proper abstraction level.

The changeset also contains a small number of unrelated fixes, such as some instances where we need to use broadcast multiplication. This is not ideal, but since this change reimplements all the layers, it was hard to separate these fixes.

**Note:** some parts are not completely perfect or crystalized yet, but I wanted to get this out before the Llama branch becomes even harder to untangle.