### PR TITLE
Implement `Tokenizer` and co. + `Repo` and co.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 /.idea
+/.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,13 @@ license = "MIT"
 homepage = "https://github.com/danieldk/oxidized-transformers"
 
 [dependencies]
-candle-core =  { git = "https://github.com/huggingface/candle.git", rev = "a90fc5c" }
+candle-core = { git = "https://github.com/huggingface/candle.git", rev = "a90fc5c" }
 candle-nn = { git = "https://github.com/huggingface/candle.git", rev = "a90fc5c" }
-serde = "1"
 snafu = "0.8"
+hf-hub = "0.3"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tokenizers = { version = "0.15", features = ["http"] }
+
+[dev-dependencies]
+rstest = "0.18"

--- a/src/layers/attention/mask.rs
+++ b/src/layers/attention/mask.rs
@@ -32,6 +32,12 @@ impl AttentionMask {
         Ok(AttentionMask { bool_mask })
     }
 
+    /// Boolean mask tensor.
+    /// *Shape:* `(batch_size, seq_len)`
+    pub fn bool_mask(&self) -> &Tensor {
+        &self.bool_mask
+    }
+
     /// Extend the mask using another mask.
     pub fn extend(&self, other: &Self) -> Result<Self, AttentionMaskError> {
         Ok(AttentionMask {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,4 +3,6 @@ pub mod error;
 pub mod kv_cache;
 pub mod layers;
 pub mod models;
+pub mod repository;
+pub mod tokenizers;
 pub mod util;

--- a/src/repository/file.rs
+++ b/src/repository/file.rs
@@ -1,0 +1,17 @@
+use std::path::Path;
+
+/// Represents a file in a repository.
+///
+/// Repository files can be a local path or a remote path exposed as a
+/// file-like object. This trait is implemented for such different types
+/// of repository files.
+pub trait RepoFile
+where
+    Self: Sized,
+{
+    /// Get the local path of the file, if it exists.
+    fn local_path(&self) -> Option<impl AsRef<Path>>;
+
+    /// Check if the file exists.
+    fn exists(&self) -> bool;
+}

--- a/src/repository/hf_hub.rs
+++ b/src/repository/hf_hub.rs
@@ -1,0 +1,116 @@
+use std::collections::HashSet;
+use std::path::Path;
+
+use hf_hub::api::sync::{Api, ApiError, ApiRepo};
+use hf_hub::{Repo as HuggingFaceRepo, RepoType as HuggingFaceRepoType};
+use snafu::{ResultExt, Snafu};
+
+use super::file::RepoFile;
+use super::local_file::LocalFile;
+use super::repo::Repo;
+use crate::error::BoxedError;
+
+/// `HfHubRepo` errors.
+#[derive(Debug, Snafu)]
+pub enum HfHubRepoError {
+    #[snafu(display("Couldn't initialize Hugging Face Hub API"))]
+    InitializeAPI { source: ApiError },
+
+    #[snafu(display("Couldn't fetch metadata for Hugging Face Hub repo"))]
+    FetchRepoMetadata { source: ApiError },
+
+    #[snafu(display("Couldn't download remote file at '{path}'"))]
+    GetRemoteFile { path: String, source: ApiError },
+}
+
+/// Hugging Face Hub repository.
+pub struct HfHubRepo {
+    api_repo: ApiRepo,
+    remote_files: HashSet<String>,
+}
+
+impl HfHubRepo {
+    /// Create a new Hugging Face Hub repository.
+    ///
+    /// * `name` - Name of the model on the Hugging Face Hub.
+    /// * `revision` - Revision of the model to load. If `None`, the main branch is used.
+    pub fn new(name: &str, revision: Option<&str>) -> Result<Self, BoxedError> {
+        let revision = revision.unwrap_or("main").to_owned();
+
+        let hub_api = Api::new().context(InitializeAPISnafu)?;
+        let api_repo = hub_api.repo(HuggingFaceRepo::with_revision(
+            name.to_owned(),
+            HuggingFaceRepoType::Model,
+            revision,
+        ));
+        let repo_info = api_repo.info().context(FetchRepoMetadataSnafu)?;
+
+        Ok(Self {
+            api_repo,
+            remote_files: repo_info
+                .siblings
+                .iter()
+                .map(|f| f.rfilename.clone())
+                .collect(),
+        })
+    }
+
+    fn remote_path_exists(&self, path: &str) -> bool {
+        self.remote_files.contains(path)
+    }
+}
+
+impl Repo for HfHubRepo {
+    type File = HfHubFile;
+
+    fn file(&self, path: impl AsRef<Path>) -> Result<Self::File, BoxedError> {
+        let path_str = path.as_ref().to_string_lossy();
+        if self.remote_path_exists(&path_str) {
+            let local_path = self
+                .api_repo
+                .get(&path_str)
+                .context(GetRemoteFileSnafu { path: path_str })?;
+
+            Ok(HfHubFile::local_file(local_path))
+        } else {
+            Ok(HfHubFile::non_existent())
+        }
+    }
+}
+
+/// Wraps either a remote file on a Hugging Face Hub repository
+/// or a local file in the Hugging Face cache.
+pub enum HfHubFile {
+    Local(LocalFile),
+    NonExistent,
+}
+
+impl HfHubFile {
+    /// Create a new `HfHubFile` from a local file.
+    ///
+    /// * `local_path` - The path of the file on the local disk.
+    pub fn local_file(local_path: impl AsRef<Path>) -> Self {
+        Self::Local(LocalFile::new(local_path))
+    }
+
+    /// Create a new `HfHubFile` that represents a non-existent (remote) file.
+    pub fn non_existent() -> Self {
+        Self::NonExistent
+    }
+}
+
+impl RepoFile for HfHubFile {
+    fn local_path(&self) -> Option<impl AsRef<Path>> {
+        match self {
+            Self::Local(l) => l.local_path(),
+            _ => None,
+        }
+    }
+
+    fn exists(&self) -> bool {
+        match self {
+            Self::Local(l) => l.exists(),
+            _ => false,
+        }
+    }
+}

--- a/src/repository/local_file.rs
+++ b/src/repository/local_file.rs
@@ -1,0 +1,38 @@
+use std::path::{Path, PathBuf};
+
+use snafu::Snafu;
+
+use super::file::RepoFile;
+
+/// `LocalFile` errors.
+#[derive(Debug, Snafu)]
+pub enum LocalFileError {
+    #[snafu(display("Couldn't open file"))]
+    Open { source: std::io::Error },
+}
+
+/// Repository file on the local machine.
+pub struct LocalFile {
+    path: PathBuf,
+}
+
+impl LocalFile {
+    /// Create a new local file.
+    ///
+    /// * `path` - The path to the file on the local machine.
+    pub fn new(path: impl AsRef<Path>) -> Self {
+        Self {
+            path: path.as_ref().to_path_buf(),
+        }
+    }
+}
+
+impl RepoFile for LocalFile {
+    fn local_path(&self) -> Option<impl AsRef<Path>> {
+        Some(self.path.as_path())
+    }
+
+    fn exists(&self) -> bool {
+        self.path.exists()
+    }
+}

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -1,0 +1,4 @@
+pub mod file;
+pub mod hf_hub;
+pub mod local_file;
+pub mod repo;

--- a/src/repository/repo.rs
+++ b/src/repository/repo.rs
@@ -1,0 +1,19 @@
+use std::path::Path;
+
+use super::file::RepoFile;
+use crate::error::BoxedError;
+
+/// Represents a repository that contains a model or tokenizer.
+pub trait Repo
+where
+    Self: Sized,
+{
+    type File: RepoFile;
+
+    /// Get a repository file.
+    ///
+    /// * `path` - The path to the file within the repository.
+    ///
+    /// Returns: A repository file object.
+    fn file(&self, path: impl AsRef<Path>) -> Result<Self::File, BoxedError>;
+}

--- a/src/tokenizers/hf_hub.rs
+++ b/src/tokenizers/hf_hub.rs
@@ -1,0 +1,20 @@
+use super::tokenizer::FromRepo;
+use crate::error::BoxedError;
+use crate::repository::hf_hub::HfHubRepo;
+
+/// Trait implemented by tokenziers that can be loaded from the Hugging Face Hub.
+pub trait FromHFHub
+where
+    Self: FromRepo,
+{
+    /// Load a tokenizer from the Hugging Face Hub.
+    ///
+    /// * name - Name of the model on the Hugging Face Hub.
+    /// * revision - Revision of the model to load. If `None`, the main branch is used.
+    ///
+    /// Returns: The tokenizer loaded from the Hugging Face Hub.
+    fn from_hf_hub(name: &str, revision: Option<&str>) -> Result<Self, BoxedError> {
+        let hf_repo = HfHubRepo::new(name, revision)?;
+        Self::from_repo(&hf_repo)
+    }
+}

--- a/src/tokenizers/hf_tokenizer.rs
+++ b/src/tokenizers/hf_tokenizer.rs
@@ -1,0 +1,447 @@
+use std::path::Path;
+use std::{fs::File, path::PathBuf};
+
+use snafu::{ensure, ResultExt, Snafu};
+use tokenizers::tokenizer::Tokenizer as HuggingFaceTokenizer;
+
+use super::pieces::PiecesWithIds;
+use super::tokenizer::FromRepo;
+use super::{
+    hf_hub::FromHFHub,
+    tokenizer::{Tokenizer, TokenizerEncodeInput},
+};
+use crate::error::BoxedError;
+use crate::repository::file::RepoFile;
+use crate::repository::repo::Repo;
+
+/// `HfTokenizer` errors.
+#[derive(Debug, Snafu)]
+pub enum HfTokenizerError {
+    #[snafu(display("Couldn't encode tokenizer inputs into pieces and ids"))]
+    Encode { source: tokenizers::Error },
+
+    #[snafu(display("Couldn't decode piece identifiers into strings"))]
+    Decode { source: tokenizers::Error },
+
+    #[snafu(display("Couldn't open 'tokenizer.json'"))]
+    OpenTokenizerJSON { source: BoxedError },
+
+    #[snafu(display("'tokenizer.json' file is missing"))]
+    MissingTokenizerJSON,
+
+    #[snafu(display("Couldn't open 'tokenizer_config.json'"))]
+    OpenTokenizerConfigJSON { source: BoxedError },
+
+    #[snafu(display("Couldn't open 'special_tokens_map.json'"))]
+    OpenSpecialTokensMapJSON { source: BoxedError },
+
+    #[snafu(display("Couldn't open JSON file at {}", path.to_string_lossy()))]
+    OpenJSON {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[snafu(display("Cannot deserialize JSON file at {}", path.to_string_lossy()))]
+    DeserializeJSON {
+        path: PathBuf,
+        source: serde_json::Error,
+    },
+
+    #[snafu(display("Couldn't load Hugging Face tokenizer from config"))]
+    LoadHFTokenizer { source: BoxedError },
+}
+
+/// Wraps the tokenizers from the HuggingFace `tokenizers` package. It supports a
+/// wide range of piece tokenizers, including word piece, byte pair encoding, and
+/// sentencepiece unigram tokenizers. This is the tokenizer that should be used
+/// in the majority of cases
+pub struct HfTokenizer {
+    tokenizer: HuggingFaceTokenizer,
+    eos_piece: Option<String>,
+}
+
+impl HfTokenizer {
+    fn new(
+        tokenizer: HuggingFaceTokenizer,
+        config: Option<&config::ConfigWithEosToken>,
+        special_tokens_map: Option<&config::ConfigWithEosToken>,
+    ) -> Self {
+        let eos_piece = config
+            .and_then(|e| e.eos_token())
+            .or_else(|| special_tokens_map.and_then(|e| e.eos_token()));
+
+        Self {
+            tokenizer,
+            eos_piece: eos_piece.cloned(),
+        }
+    }
+
+    fn try_parse_json_config(
+        path: &impl AsRef<Path>,
+    ) -> Result<Option<config::ConfigWithEosToken>, BoxedError> {
+        let file = File::open(path.as_ref()).context(OpenJSONSnafu {
+            path: path.as_ref(),
+        })?;
+
+        let deserialized: Option<config::ConfigWithEosToken> = serde_json::from_reader(file)
+            .context(DeserializeJSONSnafu {
+                path: path.as_ref().to_owned(),
+            })
+            .boxed()?;
+
+        Ok(deserialized)
+    }
+}
+
+impl Tokenizer for HfTokenizer {
+    fn encode<V, I>(&self, input: V) -> Result<PiecesWithIds, BoxedError>
+    where
+        V: AsRef<[TokenizerEncodeInput<I>]>,
+        I: AsRef<str>,
+    {
+        let converted_input = input
+            .as_ref()
+            .iter()
+            .map(|input| match input {
+                TokenizerEncodeInput::RawString(s) => {
+                    tokenizers::EncodeInput::Single(s.as_ref().into())
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let encoding = self
+            .tokenizer
+            .encode_batch(converted_input, true)
+            .context(EncodeSnafu)?;
+
+        Ok(PiecesWithIds {
+            ids: encoding
+                .iter()
+                .map(|ids| ids.get_ids().to_owned())
+                .collect(),
+            pieces: encoding
+                .iter()
+                .map(|ids| ids.get_tokens().to_owned())
+                .collect(),
+        })
+    }
+
+    fn decode<V, I>(&self, input: V, skip_special_pieces: bool) -> Result<Vec<String>, BoxedError>
+    where
+        V: AsRef<[I]>,
+        I: AsRef<[u32]>,
+    {
+        let converted_input = input
+            .as_ref()
+            .iter()
+            .map(|input| input.as_ref())
+            .collect::<Vec<_>>();
+
+        self.tokenizer
+            .decode_batch(&converted_input, skip_special_pieces)
+            .context(DecodeSnafu)
+            .boxed()
+    }
+
+    fn piece_to_id(&self, piece: impl AsRef<str>) -> Option<u32> {
+        self.tokenizer.token_to_id(piece.as_ref())
+    }
+
+    fn eos_piece(&self) -> Option<&str> {
+        self.eos_piece.as_deref()
+    }
+}
+
+impl FromRepo for HfTokenizer {
+    fn from_repo(repo: &impl Repo) -> Result<Self, BoxedError> {
+        let tokenizer_json = repo
+            .file("tokenizer.json")
+            .context(OpenTokenizerJSONSnafu)
+            .boxed()?;
+        let tokenizer_config_json = repo
+            .file("tokenizer_config.json")
+            .context(OpenTokenizerConfigJSONSnafu)
+            .boxed()?;
+        let special_tokens_map_json = repo
+            .file("special_tokens_map.json")
+            .context(OpenSpecialTokensMapJSONSnafu)
+            .boxed()?;
+
+        ensure!(tokenizer_json.exists(), MissingTokenizerJSONSnafu);
+        let tokenizer = HuggingFaceTokenizer::from_file(tokenizer_json.local_path().unwrap())
+            .context(LoadHFTokenizerSnafu)?;
+
+        let tokenizer_config = tokenizer_config_json
+            .local_path()
+            .map(|p| Self::try_parse_json_config(&p))
+            .transpose()?
+            .flatten();
+
+        let special_tokens_map = special_tokens_map_json
+            .local_path()
+            .map(|p| Self::try_parse_json_config(&p))
+            .transpose()?
+            .flatten();
+
+        Ok(Self::new(
+            tokenizer,
+            tokenizer_config.as_ref(),
+            special_tokens_map.as_ref(),
+        ))
+    }
+}
+
+impl FromHFHub for HfTokenizer {}
+
+mod config {
+    use std::collections::HashMap;
+
+    use serde::{Deserialize, Serialize};
+    use serde_json::Value;
+
+    /// Represents an EOS token in the tokenizer configuration.
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    #[serde(untagged)]
+    pub(super) enum EosTokenInConfig {
+        Default(String),
+        Wrapped { content: Option<String> },
+    }
+
+    /// Represents a tokenizer configuration that includes an EOS token.
+    /// Primarily used to with `tokenizer_config.json` and `special_tokens_map.json` files.
+    #[derive(Debug, Clone, Serialize, Deserialize, Default)]
+    pub(super) struct ConfigWithEosToken {
+        #[serde(default)]
+        eos_token: Option<EosTokenInConfig>,
+        #[serde(flatten)]
+        _extra: HashMap<String, Value>,
+    }
+
+    impl ConfigWithEosToken {
+        pub(crate) fn eos_token(&self) -> Option<&String> {
+            self.eos_token.as_ref().and_then(|e| match e {
+                EosTokenInConfig::Default(s) => Some(s),
+                EosTokenInConfig::Wrapped { content } => content.as_ref(),
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use candle_core::Device;
+    use rstest::{fixture, rstest};
+    use tokenizers::{tokenizer::Tokenizer as HuggingFaceTokenizer, EncodeInput, PaddingParams};
+
+    use super::*;
+
+    #[fixture]
+    fn short_sample_texts() -> &'static [&'static str] {
+        &[
+            "I saw a girl with a telescope.",
+            "Today we will eat poké bowl, lots of it!",
+            "Tokens which are unknown inペ mostで latinが alphabet際 vocabularies.",
+        ]
+    }
+
+    #[fixture]
+    fn long_sample_texts() -> &'static [&'static str] {
+        // Two short Wikipedia fragments from:
+        // https://en.wikipedia.org/wiki/Kinesis_(keyboard)#Contoured_/_Advantage
+        // https://en.wikipedia.org/wiki/Doom_(1993_video_game)#Engine
+        &[
+            r#"The original Model 100, released in 1992, featured a single-piece 
+        "contoured design similar to the Maltron keyboard, with the keys laid 
+        "out in a traditional QWERTY arrangement, separated into two clusters
+        "for the left and right hands.[2] A 1993 article in PC Magazine 
+        "described the US$690 (equivalent to $1,300 in 2021) keyboard's
+        'arrangement as having "the alphabet keys in precisely vertical
+        "(not diagonal) columns in two concave depressions. The Kinesis
+        "Keyboard also puts the Backspace, Delete, Enter, Space, Ctrl, Alt,
+        "Home, End, Page Up, and Page Down keys under your thumbs in the 
+        'middle.[23]"#,
+            r#"Doom was programmed largely in the ANSI C programming language, with "
+        "a few elements in assembly language. Development was done on NeXT "
+        "computers running the NeXTSTEP operating system.[35] The data used by "
+        "the game engine, including level designs and graphics files, are "
+        'stored in WAD files, short for "Where\'s All the Data?"."#,
+        ]
+    }
+
+    fn compare_tokenizer_outputs_with_hf_tokenizer(
+        model_name: &str,
+        pad_token: Option<&str>,
+        eos_piece: Option<&str>,
+        texts: &[&str],
+    ) {
+        let tokenizer = HfTokenizer::from_hf_hub(model_name, None)
+            .expect("Failed to load tokenizer from HF Hub");
+        let mut hf_tokenizer = HuggingFaceTokenizer::from_pretrained(model_name, None)
+            .expect("Failed to load HF tokenizer from HF Hub");
+
+        assert_eq!(tokenizer.eos_piece(), eos_piece.as_deref());
+
+        let our_input: Vec<TokenizerEncodeInput<_>> = texts.iter().map(|s| (*s).into()).collect();
+        let hf_input: Vec<EncodeInput> = texts.iter().map(|s| (*s).into()).collect();
+
+        let mut right_padding = PaddingParams::default();
+        right_padding.pad_token = pad_token
+            .unwrap_or(right_padding.pad_token.as_ref())
+            .to_string();
+        let mut left_padding = PaddingParams::default();
+        left_padding.direction = tokenizers::PaddingDirection::Left;
+        left_padding.pad_token = pad_token
+            .unwrap_or(right_padding.pad_token.as_ref())
+            .to_string();
+
+        let our_encoded = tokenizer.encode(our_input).expect("Failed to encode input");
+
+        // Right padding.
+        let our_encoded_padded_right = our_encoded
+            .padded_tensor(right_padding.pad_id, false, &Device::Cpu)
+            .expect("Failed to pad tensor")
+            .to_vec2::<u32>()
+            .expect("Failed to convert tensor to vec2");
+        let our_encoded_attn_mask_padded_right = our_encoded
+            .attention_mask(false, &Device::Cpu)
+            .expect("Cannot create attention mask");
+        let our_encoded_attn_mask_padded_right =
+            match our_encoded_attn_mask_padded_right.bool_mask().dims2() {
+                Ok((_, _)) => our_encoded_attn_mask_padded_right
+                    .bool_mask()
+                    .to_vec2::<u32>()
+                    .expect("Cannot convert mask to vec2"),
+                _ => our_encoded_attn_mask_padded_right
+                    .bool_mask()
+                    .squeeze(1)
+                    .expect("Failed to squeeze attn mask")
+                    .squeeze(1)
+                    .expect("Failed to squeeze attn mask")
+                    .to_vec2::<u32>()
+                    .expect("Cannot convert mask to vec2"),
+            };
+        let hf_encoded_padded_right = hf_tokenizer
+            .with_padding(Some(right_padding.clone()))
+            .encode_batch(hf_input.clone(), true)
+            .expect("Failed to encode input");
+
+        for (ours, hf) in our_encoded_padded_right
+            .iter()
+            .zip(hf_encoded_padded_right.iter())
+        {
+            assert_eq!(ours.as_slice(), hf.get_ids());
+        }
+
+        for (ours, hf) in our_encoded_attn_mask_padded_right
+            .iter()
+            .zip(hf_encoded_padded_right.iter())
+        {
+            assert_eq!(ours.as_slice(), hf.get_attention_mask());
+        }
+
+        // Left padding.
+        let our_encoded_padded_left = our_encoded
+            .padded_tensor(left_padding.pad_id, true, &Device::Cpu)
+            .expect("Failed to pad tensor")
+            .to_vec2::<u32>()
+            .expect("Failed to convert tensor to vec2");
+        let our_encoded_attn_mask_padded_left = our_encoded
+            .attention_mask(true, &Device::Cpu)
+            .expect("Cannot create attention mask");
+        let our_encoded_attn_mask_padded_left =
+            match our_encoded_attn_mask_padded_left.bool_mask().dims2() {
+                Ok((_, _)) => our_encoded_attn_mask_padded_left
+                    .bool_mask()
+                    .to_vec2::<u32>()
+                    .expect("Cannot convert mask to vec2"),
+                _ => our_encoded_attn_mask_padded_left
+                    .bool_mask()
+                    .squeeze(1)
+                    .expect("Failed to squeeze attn mask")
+                    .squeeze(1)
+                    .expect("Failed to squeeze attn mask")
+                    .to_vec2::<u32>()
+                    .expect("Cannot convert mask to vec2"),
+            };
+        let hf_encoded_padded_left = hf_tokenizer
+            .with_padding(Some(left_padding.clone()))
+            .encode_batch(hf_input.clone(), true)
+            .expect("Failed to encode input");
+
+        for (ours, hf) in our_encoded_padded_left
+            .iter()
+            .zip(hf_encoded_padded_left.iter())
+        {
+            assert_eq!(ours.as_slice(), hf.get_ids());
+        }
+
+        for (ours, hf) in our_encoded_attn_mask_padded_left
+            .iter()
+            .zip(hf_encoded_padded_left.iter())
+        {
+            assert_eq!(ours.as_slice(), hf.get_attention_mask());
+        }
+
+        // Decoding.
+        let our_decoded = tokenizer
+            .decode(our_encoded.ids.iter(), true)
+            .expect("Failed to decode input");
+        let hf_decoded = hf_tokenizer
+            .with_padding(Some(right_padding.clone()))
+            .decode_batch(
+                hf_encoded_padded_right
+                    .iter()
+                    .map(|v| v.get_ids())
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+                true,
+            )
+            .expect("Failed to decode input");
+
+        assert_eq!(our_decoded, hf_decoded);
+    }
+
+    #[rstest]
+    #[case("bert-base-cased", None, None)]
+    #[case("camembert-base", None, None)]
+    #[case("roberta-base", None, None)]
+    #[case("xlm-roberta-base", None, None)]
+    #[case("EleutherAI/gpt-neox-20b", Some("[PAD]"), Some("<|endoftext|>"))]
+    #[case("ausboss/llama-30b-supercot", Some("</s>"), Some("</s>"))]
+    #[case("tiiuae/falcon-7b", Some("<|endoftext|>"), Some("<|endoftext|>"))]
+    fn tokenizer_test_against_hugging_face_short(
+        #[case] model_name: &str,
+        #[case] pad_token: Option<&str>,
+        #[case] eos_piece: Option<&str>,
+        short_sample_texts: &[&str],
+    ) {
+        compare_tokenizer_outputs_with_hf_tokenizer(
+            model_name,
+            pad_token,
+            eos_piece,
+            short_sample_texts,
+        );
+    }
+
+    #[rstest]
+    #[case("bert-base-cased", None, None)]
+    #[case("camembert-base", None, None)]
+    #[case("roberta-base", None, None)]
+    #[case("xlm-roberta-base", None, None)]
+    #[case("EleutherAI/gpt-neox-20b", Some("[PAD]"), Some("<|endoftext|>"))]
+    #[case("ausboss/llama-30b-supercot", Some("</s>"), Some("</s>"))]
+    #[case("tiiuae/falcon-7b", Some("<|endoftext|>"), Some("<|endoftext|>"))]
+    fn tokenizer_test_against_hugging_face_long(
+        #[case] model_name: &str,
+        #[case] pad_token: Option<&str>,
+        #[case] eos_piece: Option<&str>,
+        short_sample_texts: &[&str],
+    ) {
+        compare_tokenizer_outputs_with_hf_tokenizer(
+            model_name,
+            pad_token,
+            eos_piece,
+            short_sample_texts,
+        );
+    }
+}

--- a/src/tokenizers/mod.rs
+++ b/src/tokenizers/mod.rs
@@ -1,0 +1,4 @@
+pub mod hf_hub;
+pub mod hf_tokenizer;
+pub mod pieces;
+pub mod tokenizer;

--- a/src/tokenizers/pieces.rs
+++ b/src/tokenizers/pieces.rs
@@ -1,0 +1,229 @@
+use candle_core::{Device, Tensor};
+use snafu::{OptionExt, ResultExt, Snafu};
+
+use crate::layers::attention::{AttentionMask, AttentionMaskError};
+
+/// `PiecesWithIds` errors.
+#[derive(Debug, Snafu)]
+pub enum PiecesWithIdsError {
+    #[snafu(display("Cannot calculate maximum sequence length"))]
+    MaxLength,
+
+    #[snafu(display("Cannot create padded tensor"))]
+    PaddedTensor { source: candle_core::Error },
+
+    #[snafu(display("Cannot create boolean mask"))]
+    BoolMask { source: candle_core::Error },
+
+    #[snafu(display("Cannot create attention mask"))]
+    AttentionMask { source: AttentionMaskError },
+}
+
+/// Encoded output of tokenizers.
+#[derive(Debug, Clone, Default)]
+pub struct PiecesWithIds {
+    /// Piece identifiers of each input sequence.
+    pub ids: Vec<Vec<u32>>,
+    /// Piece strings of each input sequence.
+    pub pieces: Vec<Vec<String>>,
+}
+
+impl PiecesWithIds {
+    /// Generate a padded tensor of the piece identifiers.
+    ///
+    /// * padding_id - Piece identifier of the padding piece. The actual identifier
+    ///   generally doesn't matter when an attention mask is used (and
+    ///   as long as it is a valid vocabulary index).
+    /// * pad_left - When `false`, sequences shorter than the longest sequence are
+    ///   right-padded. Otherwise, sequences are left-padding..
+    /// * device - Device on which the padded tensor is created.
+    ///
+    /// Returns: The padded piece ids.
+    /// *Shape:* ``(batch_size, max_seq_len)``
+    pub fn padded_tensor(
+        &self,
+        padding_id: u32,
+        pad_left: bool,
+        device: &Device,
+    ) -> Result<Tensor, PiecesWithIdsError> {
+        let n_sequences = self.ids.len();
+        let max_len = self
+            .ids
+            .iter()
+            .map(|ids| ids.len())
+            .max()
+            .context(MaxLengthSnafu)?;
+
+        let mut padded = vec![padding_id; n_sequences * max_len];
+        for (i, ids) in self.ids.iter().enumerate() {
+            let len = ids.len();
+            let start = if pad_left { max_len - len } else { 0 };
+            let end = if pad_left { max_len } else { len };
+            padded[i * max_len + start..i * max_len + end].copy_from_slice(ids);
+        }
+
+        Tensor::from_vec(padded, (n_sequences, max_len), device).context(PaddedTensorSnafu)
+    }
+
+    /// Generate the attention masks. The mask is equivalent to:
+    /// `ids.padded_tensor(padding_id) != padding_id`
+    ///
+    /// * pad_left - When `false`, sequences shorter than the longest sequence are
+    ///   right-padded. Otherwise, sequences are left-padding..
+    /// * device - Device on which the padded tensor is created.
+    ///
+    /// Returns: The attention mask.
+    pub fn attention_mask(
+        &self,
+        pad_left: bool,
+        device: &Device,
+    ) -> Result<AttentionMask, PiecesWithIdsError> {
+        let n_sequences = self.ids.len();
+        let max_len = self
+            .ids
+            .iter()
+            .map(|ids| ids.len())
+            .max()
+            .context(MaxLengthSnafu)?;
+
+        let mut padded = vec![0u32; n_sequences * max_len];
+        for (i, ids) in self.ids.iter().enumerate() {
+            let len = ids.len();
+            let start = if pad_left { max_len - len } else { 0 };
+            let end = if pad_left { max_len } else { len };
+            padded[i * max_len + start..i * max_len + end].fill(1u32);
+        }
+
+        let bool_mask =
+            Tensor::from_vec(padded, (n_sequences, max_len), device).context(BoolMaskSnafu)?;
+
+        AttentionMask::new(bool_mask).context(AttentionMaskSnafu)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use rstest::{fixture, rstest};
+    use snafu::{Report, Whatever};
+
+    use super::*;
+
+    #[fixture]
+    fn pieces() -> PiecesWithIds {
+        PiecesWithIds {
+            ids: vec![
+                vec![101, 7592, 2088, 102],
+                vec![101, 2023, 2003, 1996, 5409, 1999, 1996, 2088, 102],
+            ],
+            pieces: vec![
+                vec![
+                    "[CLS]".to_owned(),
+                    "hello".to_owned(),
+                    "world".to_owned(),
+                    "[SEP]".to_owned(),
+                ],
+                vec![
+                    "[CLS]".to_owned(),
+                    "this".to_owned(),
+                    "is".to_owned(),
+                    "the".to_owned(),
+                    "worst".to_owned(),
+                    "in".to_owned(),
+                    "the".to_owned(),
+                    "world".to_owned(),
+                    "[SEP]".to_owned(),
+                ],
+            ],
+        }
+    }
+
+    #[rstest]
+    fn piecewithids_attention_mask(pieces: PiecesWithIds) -> Report<Whatever> {
+        Report::capture(|| {
+            let mask = pieces
+                .attention_mask(false, &Device::Cpu)
+                .expect("Cannot create attention mask");
+
+            assert_eq!(
+                mask.bool_mask()
+                    .squeeze(1)
+                    .expect("Failed to squeeze attn mask")
+                    .squeeze(1)
+                    .expect("Failed to squeeze attn mask")
+                    .to_vec2::<u32>()
+                    .expect("Cannot convert mask to vec2")
+                    .as_slice(),
+                &[
+                    vec![1, 1, 1, 1, 0, 0, 0, 0, 0],
+                    vec![1, 1, 1, 1, 1, 1, 1, 1, 1]
+                ]
+            );
+
+            let mask = pieces
+                .attention_mask(true, &Device::Cpu)
+                .expect("Cannot create attention mask");
+
+            assert_eq!(
+                mask.bool_mask()
+                    .squeeze(1)
+                    .expect("Failed to squeeze attn mask")
+                    .squeeze(1)
+                    .expect("Failed to squeeze attn mask")
+                    .to_vec2::<u32>()
+                    .expect("Cannot convert mask to vec2")
+                    .as_slice(),
+                &[
+                    vec![0, 0, 0, 0, 0, 1, 1, 1, 1,],
+                    vec![1, 1, 1, 1, 1, 1, 1, 1, 1]
+                ]
+            );
+
+            Ok(())
+        })
+    }
+
+    #[rstest]
+    fn piecewithids_padded_tensor(pieces: PiecesWithIds) -> Report<Whatever> {
+        Report::capture(|| {
+            let padding_id = u32::MAX;
+
+            let padded = pieces
+                .padded_tensor(padding_id, false, &Device::Cpu)
+                .expect("Cannot create padded tensor");
+
+            assert_eq!(
+                padded
+                    .to_vec2::<u32>()
+                    .expect("Cannot convert to vec2")
+                    .as_slice(),
+                &[
+                    vec![
+                        101, 7592, 2088, 102, padding_id, padding_id, padding_id, padding_id,
+                        padding_id
+                    ],
+                    vec![101, 2023, 2003, 1996, 5409, 1999, 1996, 2088, 102]
+                ]
+            );
+
+            let padded = pieces
+                .padded_tensor(padding_id, true, &Device::Cpu)
+                .expect("Cannot create padded tensor");
+
+            assert_eq!(
+                padded
+                    .to_vec2::<u32>()
+                    .expect("Cannot convert to vec2")
+                    .as_slice(),
+                &[
+                    vec![
+                        padding_id, padding_id, padding_id, padding_id, padding_id, 101, 7592,
+                        2088, 102
+                    ],
+                    vec![101, 2023, 2003, 1996, 5409, 1999, 1996, 2088, 102]
+                ]
+            );
+
+            Ok(())
+        })
+    }
+}

--- a/src/tokenizers/tokenizer.rs
+++ b/src/tokenizers/tokenizer.rs
@@ -1,0 +1,75 @@
+use super::pieces::PiecesWithIds;
+use crate::{error::BoxedError, repository::repo::Repo};
+
+/// Input for encoding with a tokenizer.
+pub enum TokenizerEncodeInput<I>
+where
+    I: AsRef<str>,
+{
+    RawString(I),
+    // TODO: add chunked input
+}
+
+impl From<String> for TokenizerEncodeInput<String> {
+    fn from(s: String) -> Self {
+        TokenizerEncodeInput::RawString(s)
+    }
+}
+
+impl From<&str> for TokenizerEncodeInput<String> {
+    fn from(s: &str) -> Self {
+        TokenizerEncodeInput::RawString(s.to_owned())
+    }
+}
+
+/// Trait implemented by all tokenizers.
+pub trait Tokenizer {
+    /// Split one or more texts into pieces.
+    ///
+    /// * input - Sequences to tokenize. If the sequences are
+    ///   strings, they are automatically converted to chunks.
+    ///
+    /// Returns: Pieces in each sequence.
+    fn encode<V, I>(&self, input: V) -> Result<PiecesWithIds, BoxedError>
+    where
+        V: AsRef<[TokenizerEncodeInput<I>]>,
+        I: AsRef<str>;
+
+    /// Reconstruct string sequences from piece identifiers.
+    ///
+    /// * input - The piece identifiers to reconstruct the strings from.
+    /// * skip_special_pieces - Skip special pieces during decoding.
+    ///
+    /// Returns: The decoded strings.
+    fn decode<V, I>(&self, input: V, skip_special_pieces: bool) -> Result<Vec<String>, BoxedError>
+    where
+        V: AsRef<[I]>,
+        I: AsRef<[u32]>;
+
+    /// Get the ID for a single piece.
+    ///
+    /// * piece - The piece to look up the identifier for.
+    ///
+    /// Returns: The piece identifier, `None` when the piece
+    /// is unknown.
+    fn piece_to_id(&self, piece: impl AsRef<str>) -> Option<u32>;
+
+    /// Get the end-of-sequence piece.
+    ///
+    /// Returns: The end-of-sequence piece or
+    /// `None` when this piece is not defined.
+    fn eos_piece(&self) -> Option<&str>;
+}
+
+/// Trait implemented by tokenizers that can be loaded from a repository.
+pub trait FromRepo
+where
+    Self: Sized + Tokenizer,
+{
+    /// Load a tokenizer from a repository.
+    ///
+    /// * repo - The repository to load the tokenizer from.
+    ///
+    /// Returns: The tokenizer loaded from the repository.
+    fn from_repo(repo: &impl Repo) -> Result<Self, BoxedError>;
+}


### PR DESCRIPTION
The `Tokenizer` trait is the main entry point for tokenization. The trait is implemented for `HFTokenizer` which is a wrapper around the `tokenizers` library.

Loading is implemented through the `FromHFHub` trait, which in turn relies on the `FromRepo` trait. The `repository` module contains a minimal implementation of a repository system.