### PR TITLE
Wire up key-value cache

### DIFF
--- a/src/architectures/decoder.rs
+++ b/src/architectures/decoder.rs
@@ -5,6 +5,7 @@ use candle_nn::VarBuilder;
 
 use crate::architectures::output::LayerOutputs;
 use crate::error::BoxedError;
+use crate::kv_cache::KeyValueCache;
 use crate::layers::attention::AttentionMask;
 
 /// Decoder output.
@@ -65,7 +66,7 @@ pub trait Decoder {
         &self,
         piece_ids: &Tensor,
         attention_mask: &AttentionMask,
-        cache: Option<&[Self::Cache]>,
+        cache: Option<impl AsRef<[KeyValueCache]>>,
         positions: Option<&Tensor>,
         train: bool,
     ) -> Result<DecoderOutput<Self::Cache>, BoxedError>;

--- a/src/kv_cache.rs
+++ b/src/kv_cache.rs
@@ -1,7 +1,10 @@
 use candle_core::Tensor;
 
+use crate::layers::attention::AttentionMask;
+
 /// Cache type for layers that cache keys and values.
 pub struct KeyValueCache {
     pub key: Tensor,
     pub value: Tensor,
+    pub attention_mask: AttentionMask,
 }

--- a/src/layers/attention/mask.rs
+++ b/src/layers/attention/mask.rs
@@ -1,51 +1,56 @@
-use candle_core::Tensor;
-use snafu::{ResultExt, Snafu};
+use candle_core::{DType, IndexOp, Tensor};
+use snafu::{ensure, ResultExt, Snafu};
 
-/// Errors for attention masks.
 #[derive(Debug, Snafu)]
-pub enum AttentionMaskError {
+pub enum QueryKeyAttentionMaskError {
     #[snafu(display("Cannot apply logits mask"))]
     ApplyLogitsMask { source: candle_core::Error },
 
     #[snafu(display("Cannot intersect masks"))]
     IntersectMasks { source: candle_core::Error },
-
-    #[snafu(display("Cannot reshape 2D mask to 4D"))]
-    ReshapeMask { source: candle_core::Error },
 }
 
 /// Attention mask.
 ///
-/// Sequence elements for which the corresponding mask element is set to
-/// `False` are ignored during attention calculation.
+/// A 4D attention mask with shape *(batch_size, heads, query_len, key_len)*.
+/// Elements for which the corresponding mask element is set to `False` are
+/// ignored during attention calculation.
 #[derive(Clone, Debug)]
-pub struct AttentionMask {
+pub struct QueryKeyAttentionMask {
     bool_mask: Tensor,
 }
 
-impl AttentionMask {
-    /// Create an attention mask.
-    ///
-    /// * `bool_mask` - Boolean mask tensor.
-    ///   *Shape:* `(batch_size, seq_len)`
-    pub fn new(bool_mask: Tensor) -> Result<Self, AttentionMaskError> {
-        let bool_mask = match bool_mask.shape().dims2() {
-            Ok((batch_len, key_len)) => bool_mask
-                .reshape((batch_len, 1, 1, key_len))
-                .context(ReshapeMaskSnafu)?,
-            _ => bool_mask,
-        };
-
-        Ok(AttentionMask { bool_mask })
+impl From<AttentionMask> for QueryKeyAttentionMask {
+    fn from(attention_mask: AttentionMask) -> Self {
+        QueryKeyAttentionMask::from(&attention_mask)
     }
+}
 
-    /// Use the attention mask to mask attention logits.
+impl From<&AttentionMask> for QueryKeyAttentionMask {
+    fn from(attention_mask: &AttentionMask) -> Self {
+        let (batch_len, key_len) = attention_mask
+            .bool_mask
+            .shape()
+            .dims2()
+            .expect("input mask must have two dimensions");
+        QueryKeyAttentionMask {
+            bool_mask: attention_mask
+                .bool_mask
+                .reshape((batch_len, 1, 1, key_len))
+                .expect("Cannot reshape input mask"),
+        }
+    }
+}
+
+impl QueryKeyAttentionMask {
+    /// Use the attention mask to mask logits.
+    ///
     /// * input - Tensor to which the mask is applied.
     ///   *Shape:* `(batch_size, heads, query_len, key_len)`
     ///
     /// Returns: Logits with the attention mask applied.
     /// *Shape:* `(batch_size, heads, query_len, key_len)`
-    pub fn apply_logit_mask(&self, input: &Tensor) -> Result<Tensor, AttentionMaskError> {
+    pub fn apply_logit_mask(&self, input: &Tensor) -> Result<Tensor, QueryKeyAttentionMaskError> {
         // Underflows to -inf for more narrow floating point types, which
         // is ok for masking.
         let blocked_value = Tensor::try_from(f32::MIN)
@@ -58,12 +63,110 @@ impl AttentionMask {
     }
 
     /// Merge this attention mask with another attention mask.
-    pub fn intersect(&self, other: &AttentionMask) -> Result<AttentionMask, AttentionMaskError> {
-        Ok(AttentionMask {
+    pub fn intersect(
+        &self,
+        other: &QueryKeyAttentionMask,
+    ) -> Result<QueryKeyAttentionMask, QueryKeyAttentionMaskError> {
+        Ok(QueryKeyAttentionMask {
             bool_mask: self
                 .bool_mask
                 .broadcast_mul(&other.bool_mask)
                 .context(IntersectMasksSnafu)?,
+        })
+    }
+}
+
+/// Errors for attention masks.
+#[derive(Debug, Snafu)]
+pub enum AttentionMaskError {
+    #[snafu(display("Cannot concatenate masks"))]
+    ConcatMasks { source: candle_core::Error },
+
+    #[snafu(display("Attention mask must be 2D, was {}D", n_dims))]
+    InvalidDims { n_dims: usize },
+}
+
+/// Attention mask.
+///
+/// Sequence elements for which the corresponding mask element is set to
+/// `False` are ignored during attention calculation. Guaranteed to be
+/// a 2D array.
+#[derive(Clone, Debug)]
+pub struct AttentionMask {
+    bool_mask: Tensor,
+}
+
+impl AttentionMask {
+    /// Create an input attention mask.
+    ///
+    /// * `bool_mask` - Boolean mask tensor.
+    ///   *Shape:* `(batch_size, seq_len)`
+    pub fn new(bool_mask: Tensor) -> Result<Self, AttentionMaskError> {
+        let n_dims = bool_mask.dims().len();
+        ensure!(n_dims == 2, InvalidDimsSnafu { n_dims });
+        Ok(AttentionMask { bool_mask })
+    }
+
+    /// Extend the mask using another mask.
+    pub fn extend(&self, other: &Self) -> Result<Self, AttentionMaskError> {
+        Ok(AttentionMask {
+            bool_mask: Tensor::cat(&[&self.bool_mask, &other.bool_mask], 1)
+                .context(ConcatMasksSnafu)?,
+        })
+    }
+}
+
+#[derive(Debug, Snafu)]
+pub enum CausalMaskError {
+    #[snafu(display("Cannot create causal mask"))]
+    CreateMask { source: candle_core::Error },
+
+    #[snafu(display("Key has invalid number of dimensions"))]
+    KeyDim { source: candle_core::Error },
+
+    #[snafu(display("Query has invalid number of dimensions"))]
+    QueryDim { source: candle_core::Error },
+
+    #[snafu(display("Query length {query_len} must not be larger than key length {key_len}"))]
+    QueryLen { key_len: usize, query_len: usize },
+
+    #[snafu(display("Cannot slice causal mask to key/query size"))]
+    SliceMask { source: candle_core::Error },
+}
+
+/// Trait for creating causal masks.
+pub trait CausalMask: Sized {
+    type Error;
+
+    /// Create a causal mask for the given query and key.
+    ///
+    /// A causal mask ensures that tokens cannot attend to succeeding tokens.
+    ///
+    /// * `query` - Query tensor.
+    ///   *Shape:* `(batch_size, heads, query_len, width)`
+    /// * `key` - Key tensor.
+    ///   *Shape:* `(batch_size, heads, key_len, width)`
+    fn causal_mask(query: &Tensor, key: &Tensor) -> Result<Self, Self::Error>;
+}
+
+impl CausalMask for QueryKeyAttentionMask {
+    type Error = CausalMaskError;
+
+    fn causal_mask(query: &Tensor, key: &Tensor) -> Result<Self, Self::Error> {
+        let (_, _, query_len, _) = query.shape().dims4().context(QueryDimSnafu)?;
+        let (_, _, key_len, _) = key.shape().dims4().context(KeyDimSnafu)?;
+
+        // Slicing will fail down the line if the query length is greater than
+        // the key length.
+        ensure!(query_len <= key_len, QueryLenSnafu { key_len, query_len });
+
+        let causal_mask = Tensor::tril2(key_len, DType::U32, key.device())
+            .and_then(|mask| mask.reshape((1, 1, key_len, key_len)))
+            .context(CreateMaskSnafu)?;
+        Ok(Self {
+            bool_mask: causal_mask
+                .i((.., .., key_len - query_len..key_len, ..key_len))
+                .context(SliceMaskSnafu)?,
         })
     }
 }

--- a/src/layers/attention/mod.rs
+++ b/src/layers/attention/mod.rs
@@ -4,7 +4,10 @@ use candle_core::Tensor;
 use candle_nn::VarBuilder;
 
 mod mask;
-pub use mask::{AttentionMask, AttentionMaskError};
+pub use mask::{
+    AttentionMask, AttentionMaskError, CausalMask, CausalMaskError, QueryKeyAttentionMask,
+    QueryKeyAttentionMaskError,
+};
 
 mod sdpa;
 pub use sdpa::{
@@ -20,6 +23,7 @@ pub use self_attention::{
 };
 
 use crate::error::BoxedError;
+use crate::kv_cache::KeyValueCache;
 
 /// Trait for attention modules.
 pub trait Attention {
@@ -37,9 +41,10 @@ pub trait Attention {
         &self,
         input: &Tensor,
         attention_mask: &AttentionMask,
+        cache: Option<&KeyValueCache>,
         train: bool,
         use_causal_mask: bool,
-    ) -> Result<Tensor, BoxedError>;
+    ) -> Result<(Tensor, Option<KeyValueCache>), BoxedError>;
 }
 
 /// Build an attention module.
@@ -73,7 +78,7 @@ pub trait AttentionScorer {
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
-        attention_mask: &AttentionMask,
+        attention_mask: &QueryKeyAttentionMask,
         train: bool,
     ) -> Result<Tensor, BoxedError>;
 }

--- a/src/layers/attention/sdpa.rs
+++ b/src/layers/attention/sdpa.rs
@@ -5,8 +5,8 @@ use snafu::{ResultExt, Snafu};
 
 use crate::error::BoxedError;
 use crate::layers::attention::{
-    AttentionLinearBiases, AttentionLinearBiasesConfig, AttentionLinearBiasesError, AttentionMask,
-    AttentionMaskError, AttentionScorer, BuildAttentionScorer,
+    AttentionLinearBiases, AttentionLinearBiasesConfig, AttentionLinearBiasesError,
+    AttentionScorer, BuildAttentionScorer, QueryKeyAttentionMask, QueryKeyAttentionMaskError,
 };
 use crate::layers::build_module::BuildModule;
 use crate::layers::identity::Identity;
@@ -69,7 +69,7 @@ pub enum ScaledDotProductAttentionError {
     AttentionScores { source: candle_core::Error },
 
     #[snafu(display("Cannot apply attention mask"))]
-    AttentionMask { source: AttentionMaskError },
+    AttentionMask { source: QueryKeyAttentionMaskError },
 
     #[snafu(display("Cannot weigh representations using attention mask"))]
     AttentionWeight { source: candle_core::Error },
@@ -98,7 +98,7 @@ impl AttentionScorer for ScaledDotProductAttention {
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
-        attention_mask: &AttentionMask,
+        attention_mask: &QueryKeyAttentionMask,
         train: bool,
     ) -> Result<Tensor, BoxedError> {
         // TODO: add code path for flash attention, but verify the attention

--- a/src/layers/transformer/layer.rs
+++ b/src/layers/transformer/layer.rs
@@ -219,7 +219,7 @@ impl TransformerLayer {
         &self,
         input: &Tensor,
         attention_mask: &AttentionMask,
-        _cache: Option<&KeyValueCache>,
+        cache: Option<&KeyValueCache>,
         _positions: Option<&Tensor>,
         train: bool,
         use_causal_mask: bool,
@@ -227,9 +227,9 @@ impl TransformerLayer {
         let mut residual = input.clone();
 
         // Apply attention block.
-        let attn_out = self
+        let (attn_out, cache) = self
             .mha
-            .forward_t(input, attention_mask, train, use_causal_mask)
+            .forward_t(input, attention_mask, cache, train, use_causal_mask)
             .context(SelfAttentionSnafu)?;
 
         // Apply post-attention residual connection.
@@ -261,7 +261,7 @@ impl TransformerLayer {
             .and_then(|xs| self.ffn_residual_layer_norm.forward_t(&xs, train))
             .context(ResidualSnafu)?;
 
-        Ok((output, None))
+        Ok((output, cache))
     }
 }
 


### PR DESCRIPTION
This change wires up the key-value cache, so that it is used in the decoder when passing a cache. This requires a few related changes:

- Separate 2D (`InputMask`) and 4D (`AttentionMask`) masks.
- Store `InputMask` in the key-value cache, so that we don't have to pass the full attention mask on each `Decoder::forward_t` call. This is more intuitive, since the input and the mask will always be the same size.
- Fix an incorrect dimension in `QueryKeyRotaryEmbeddings`.
- Fix an off-by-one in `RotaryEmbeddings` when computing positions from a mask.

The changes were tested with the Llama decoder on a branch.