### PR TITLE
Better structure the KV cache, make it mutable, non-optional

### DIFF
--- a/src/architectures/decoder.rs
+++ b/src/architectures/decoder.rs
@@ -5,26 +5,20 @@ use candle_nn::VarBuilder;
 
 use crate::architectures::output::LayerOutputs;
 use crate::error::BoxedError;
-use crate::kv_cache::KeyValueCache;
 use crate::layers::attention::AttentionMask;
 
 /// Decoder output.
-pub struct DecoderOutput<C> {
+pub struct DecoderOutput {
     all_outputs: Vec<Tensor>,
-    cache: Option<Vec<C>>,
 }
 
-impl<C> DecoderOutput<C> {
-    pub fn new(all_outputs: Vec<Tensor>, cache: Option<Vec<C>>) -> Self {
-        Self { all_outputs, cache }
-    }
-
-    pub fn cache(&self) -> Option<&[C]> {
-        self.cache.as_deref()
+impl DecoderOutput {
+    pub fn new(all_outputs: Vec<Tensor>) -> Self {
+        Self { all_outputs }
     }
 }
 
-impl<C> LayerOutputs for DecoderOutput<C> {
+impl LayerOutputs for DecoderOutput {
     fn layer_outputs(&self) -> &[Tensor] {
         &self.all_outputs
     }
@@ -66,10 +60,10 @@ pub trait Decoder {
         &self,
         piece_ids: &Tensor,
         attention_mask: &AttentionMask,
-        cache: Option<impl AsRef<[KeyValueCache]>>,
+        cache: &mut Self::Cache,
         positions: Option<&Tensor>,
         train: bool,
-    ) -> Result<DecoderOutput<Self::Cache>, BoxedError>;
+    ) -> Result<DecoderOutput, BoxedError>;
 }
 
 /// Trait for decoder layers.
@@ -100,10 +94,10 @@ pub trait DecoderLayer {
         &self,
         piece_ids: &Tensor,
         attention_mask: &AttentionMask,
-        cache: Option<&Self::Cache>,
+        cache: &mut Self::Cache,
         positions: Option<&Tensor>,
         train: bool,
-    ) -> Result<(Tensor, Option<Self::Cache>), BoxedError>;
+    ) -> Result<Tensor, BoxedError>;
 }
 
 /// Trait for building decoder layers.

--- a/src/kv_cache.rs
+++ b/src/kv_cache.rs
@@ -1,10 +1,203 @@
-use candle_core::Tensor;
+use std::iter::repeat_with;
+use std::ops::{Index, IndexMut};
 
-use crate::layers::attention::AttentionMask;
+use candle_core::{DType, Device, Tensor};
+use snafu::{ResultExt, Snafu};
+
+/// Errors in layer cache operations.
+#[derive(Debug, Snafu)]
+pub enum LayerKeyValueCacheError {
+    #[snafu(display("Failed to create empty key"))]
+    CreateEmptyKey { source: candle_core::Error },
+
+    #[snafu(display("Failed to create empty value"))]
+    CreateEmptyValue { source: candle_core::Error },
+
+    #[snafu(display("Failed to extend key"))]
+    ExtendKey { source: candle_core::Error },
+
+    #[snafu(display("Failed to extend value"))]
+    ExtendValue { source: candle_core::Error },
+}
+
+/// Internal representation of `LayerKeyValueCache`.
+enum LayerKeyValueCacheEnum {
+    Cache { key: Tensor, value: Tensor },
+
+    NoCache,
+}
+
+/// Key-value cache for a layer.
+pub struct LayerKeyValueCache(LayerKeyValueCacheEnum);
+
+impl LayerKeyValueCache {
+    /// Create an empty layer cache.
+    ///
+    /// * `batch_size` - Batch size.
+    /// * `hidden_width` - Hidden width.
+    /// * `n_key_value_heads` - Number of key-value heads.
+    /// * `dtype` - Cache data type.
+    /// * `device` - Device to store the cache on.
+    pub fn cache(
+        batch_size: usize,
+        hidden_width: usize,
+        n_key_value_heads: usize,
+        dtype: DType,
+        device: &Device,
+    ) -> Result<Self, LayerKeyValueCacheError> {
+        Ok(LayerKeyValueCache(LayerKeyValueCacheEnum::Cache {
+            key: Tensor::zeros(
+                (batch_size, n_key_value_heads, 0, hidden_width),
+                dtype,
+                device,
+            )
+            .context(CreateEmptyKeySnafu)?,
+            value: Tensor::zeros(
+                (batch_size, n_key_value_heads, 0, hidden_width),
+                dtype,
+                device,
+            )
+            .context(CreateEmptyValueSnafu)?,
+        }))
+    }
+
+    /// Create a no-op cache.
+    ///
+    /// This type of cache does not store anything. Updates to the cache are
+    /// discarded.
+    pub fn no_cache() -> Self {
+        Self(LayerKeyValueCacheEnum::NoCache)
+    }
+
+    /// Get the cached key.
+    pub fn key(&self) -> Option<&Tensor> {
+        match &self.0 {
+            LayerKeyValueCacheEnum::Cache { key, .. } => Some(key),
+            LayerKeyValueCacheEnum::NoCache => None,
+        }
+    }
+
+    /// Get the cached value.
+    pub fn value(&self) -> Option<&Tensor> {
+        match &self.0 {
+            LayerKeyValueCacheEnum::Cache { value, .. } => Some(value),
+            LayerKeyValueCacheEnum::NoCache => None,
+        }
+    }
+
+    /// Update the cache.
+    ///
+    /// This adds the new key/value tensors to the cache.
+    ///
+    /// * `new_key` - New key tensor.
+    /// * `new_value` - New value tensor.
+    pub fn update(
+        &mut self,
+        new_key: &Tensor,
+        new_value: &Tensor,
+    ) -> Result<(), LayerKeyValueCacheError> {
+        match &mut self.0 {
+            LayerKeyValueCacheEnum::Cache { key, value } => {
+                *key = Tensor::cat(&[&*key, new_key], 2).context(ExtendKeySnafu)?;
+                *value = Tensor::cat(&[&*value, new_value], 2).context(ExtendKeySnafu)?;
+            }
+            LayerKeyValueCacheEnum::NoCache => (),
+        }
+
+        Ok(())
+    }
+}
+
+/// Key-value cache errors.
+#[derive(Debug, Snafu)]
+pub enum KeyValueCacheError {
+    #[snafu(display("Failed to create layer cache"))]
+    CreateLayerKeyValueCache { source: LayerKeyValueCacheError },
+}
+
+/// Internal representation of `KeyValueCache`.
+enum KeyValueCacheEnum {
+    #[allow(private_interfaces)]
+    Cache {
+        layer_caches: Vec<LayerKeyValueCache>,
+    },
+
+    #[allow(private_interfaces)]
+    NoCache {
+        stub: LayerKeyValueCache,
+
+        // Note: it's a bit nonsensical to have this, but we need it to
+        // return the number of layers in the cache uniformly.
+        n_layers: usize,
+    },
+}
 
 /// Cache type for layers that cache keys and values.
-pub struct KeyValueCache {
-    pub key: Tensor,
-    pub value: Tensor,
-    pub attention_mask: AttentionMask,
+pub struct KeyValueCache(KeyValueCacheEnum);
+
+impl KeyValueCache {
+    /// Create a key-value cache.
+    ///
+    /// * `batch_size` - Batch size.
+    /// * `hidden_width` - Hidden width.
+    /// * `n_key_value_heads` - Number of key-value heads.
+    /// * `n_layers` - Number of hidden layers.
+    /// * `dtype` - Cache data type.
+    /// * `device` - Device to store the cache on.
+    pub fn cache(
+        batch_size: usize,
+        hidden_width: usize,
+        n_key_value_heads: usize,
+        n_layers: usize,
+        dtype: DType,
+        device: &Device,
+    ) -> Result<Self, KeyValueCacheError> {
+        let layer_caches = repeat_with(|| {
+            LayerKeyValueCache::cache(batch_size, hidden_width, n_key_value_heads, dtype, device)
+        })
+        .take(n_layers)
+        .collect::<Result<Vec<_>, _>>()
+        .context(CreateLayerKeyValueCacheSnafu)?;
+
+        Ok(Self(KeyValueCacheEnum::Cache { layer_caches }))
+    }
+
+    /// Get the number of layers in the cache.
+    pub fn n_layers(&self) -> usize {
+        match &self.0 {
+            KeyValueCacheEnum::Cache { layer_caches } => layer_caches.len(),
+            KeyValueCacheEnum::NoCache { n_layers, .. } => *n_layers,
+        }
+    }
+
+    /// Create a no-op cache.
+    ///
+    /// This type of cache does not store anything. Updates to the cache are
+    /// discarded.
+    pub fn no_cache(n_layers: usize) -> Self {
+        Self(KeyValueCacheEnum::NoCache {
+            stub: LayerKeyValueCache::no_cache(),
+            n_layers,
+        })
+    }
+}
+
+impl Index<usize> for KeyValueCache {
+    type Output = LayerKeyValueCache;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        match &self.0 {
+            KeyValueCacheEnum::Cache { layer_caches } => &layer_caches[index],
+            KeyValueCacheEnum::NoCache { stub, .. } => stub,
+        }
+    }
+}
+
+impl IndexMut<usize> for KeyValueCache {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        match &mut self.0 {
+            KeyValueCacheEnum::Cache { layer_caches } => &mut layer_caches[index],
+            KeyValueCacheEnum::NoCache { stub, .. } => stub,
+        }
+    }
 }

--- a/src/layers/attention/alibi.rs
+++ b/src/layers/attention/alibi.rs
@@ -184,10 +184,10 @@ impl AttentionLinearBiases {
 
 #[cfg(test)]
 mod tests {
-    use crate::util::tests::assert_close;
     use candle_core::{DType, Device, Tensor};
 
     use super::AttentionLinearBiasesConfig;
+    use crate::util::tests::assert_close;
 
     #[test]
     fn test_attention_linear_biases_slopes() {

--- a/src/layers/attention/mod.rs
+++ b/src/layers/attention/mod.rs
@@ -21,7 +21,7 @@ pub use self_attention::{
 };
 
 use crate::error::BoxedError;
-use crate::kv_cache::KeyValueCache;
+use crate::kv_cache::LayerKeyValueCache;
 
 /// Trait for attention modules.
 pub trait Attention {
@@ -39,11 +39,11 @@ pub trait Attention {
         &self,
         input: &Tensor,
         attention_mask: &AttentionMask,
-        cache: Option<&KeyValueCache>,
+        cache: &mut LayerKeyValueCache,
         positions: Option<&Tensor>,
         train: bool,
         use_causal_mask: bool,
-    ) -> Result<(Tensor, Option<KeyValueCache>), BoxedError>;
+    ) -> Result<Tensor, BoxedError>;
 }
 
 /// Build an attention module.

--- a/src/layers/transformer/embeddings.rs
+++ b/src/layers/transformer/embeddings.rs
@@ -1,8 +1,8 @@
-use crate::error::BoxedError;
 use candle_core::{Module, ModuleT, Tensor};
 use candle_nn::{embedding, Embedding, VarBuilder};
 use snafu::{ResultExt, Snafu};
 
+use crate::error::BoxedError;
 use crate::layers::build_module::BuildModule;
 use crate::layers::identity::Identity;
 


### PR DESCRIPTION
Before this change, the KV cache was passed around as `Option<Vec<KeyValueCache>>`. This has several issues. First, the use of an option requires a lot of wrapping and unwrapping. Second, the cache is immutable and in the future we want to pre-allocate the cache and mutate it in-place to avoid allocations/copies.

This change removes the `Option` wrapping and makes the cache mutable. We don't do in-place updates yet.

The type for the cache itself is now `KeyValueCache` and the cache for a layer is `LayerKeyValueCache`. Decoders now always require passing a `KeyValueCache` object. There is a special constructor, `KeyValueCache::no_cache` that creates a no-op cache.

This approach allows us to treat the cache/no-cache cases in the same way. The same operations are applied, but they are just ignored when `no_cache` is used.