### PR TITLE
Add the `BuildArchitecture` trait

### DIFF
--- a/src/architectures/causal_lm.rs
+++ b/src/architectures/causal_lm.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use candle_core::Tensor;
 use candle_nn::VarBuilder;
 
-use crate::architectures::{DecoderOutput, LayerOutputs};
+use crate::architectures::{BuildArchitecture, DecoderOutput, LayerOutputs};
 use crate::error::BoxedError;
 use crate::layers::attention::AttentionMask;
 
@@ -49,11 +49,22 @@ impl LayerOutputs for CausalLMOutput {
 
 /// Trait for building causal language models.
 pub trait BuildCausalLM: Debug {
-    /// Causal language model type.
     type CausalLM: CausalLM;
 
     /// Build a causal language model.
     fn build(&self, vb: VarBuilder) -> Result<Self::CausalLM, BoxedError>;
+}
+
+impl<C> BuildCausalLM for C
+where
+    C: BuildArchitecture + Debug,
+    C::Architecture: CausalLM,
+{
+    type CausalLM = C::Architecture;
+
+    fn build(&self, vb: VarBuilder) -> Result<Self::CausalLM, BoxedError> {
+        self.build(vb)
+    }
 }
 
 /// Trait for causal language models.

--- a/src/architectures/decoder.rs
+++ b/src/architectures/decoder.rs
@@ -1,5 +1,6 @@
 use std::fmt::Debug;
 
+use crate::architectures::BuildArchitecture;
 use candle_core::Tensor;
 use candle_nn::VarBuilder;
 
@@ -35,6 +36,18 @@ pub trait BuildDecoder: Debug {
 
     /// Build a decoder.
     fn build(&self, vb: VarBuilder) -> Result<Self::Decoder, BoxedError>;
+}
+
+impl<D> BuildDecoder for D
+where
+    D: BuildArchitecture + Debug,
+    D::Architecture: Decoder,
+{
+    type Decoder = D::Architecture;
+
+    fn build(&self, vb: VarBuilder) -> Result<Self::Decoder, BoxedError> {
+        self.build(vb)
+    }
 }
 
 /// Trait for decoders.

--- a/src/architectures/mod.rs
+++ b/src/architectures/mod.rs
@@ -1,5 +1,7 @@
 /// Traits for model architectures.
 mod causal_lm;
+
+use candle_nn::VarBuilder;
 pub use causal_lm::{BuildCausalLM, CausalLM, CausalLMOutput};
 
 mod decoder;
@@ -9,4 +11,14 @@ mod encoder;
 pub use encoder::{BuildEncoderLayer, EncoderLayer, EncoderOutput};
 
 mod output;
+use crate::error::BoxedError;
 pub use output::LayerOutputs;
+
+/// Trait for building model architectures.
+pub trait BuildArchitecture {
+    /// The architecture to build.
+    type Architecture;
+
+    /// Build the architecture.
+    fn build(&self, vb: VarBuilder) -> Result<Self::Architecture, BoxedError>;
+}

--- a/src/models/transformer/causal_lm.rs
+++ b/src/models/transformer/causal_lm.rs
@@ -2,9 +2,8 @@ use candle_core::{ModuleT, Tensor};
 use candle_nn::{linear_no_bias, VarBuilder};
 use snafu::{ResultExt, Snafu};
 
-use crate::architectures::{
-    BuildCausalLM, BuildDecoder, CausalLM, CausalLMOutput, Decoder, LayerOutputs,
-};
+use crate::architectures::BuildArchitecture;
+use crate::architectures::{BuildDecoder, CausalLM, CausalLMOutput, Decoder, LayerOutputs};
 use crate::error::BoxedError;
 use crate::kv_cache::KeyValueCache;
 use crate::layers::attention::AttentionMask;
@@ -54,10 +53,10 @@ impl Default for TransformerCausalLMConfig {
     }
 }
 
-impl BuildCausalLM for TransformerCausalLMConfig {
-    type CausalLM = TransformerCausalLM;
+impl BuildArchitecture for TransformerCausalLMConfig {
+    type Architecture = TransformerCausalLM;
 
-    fn build(&self, vb: VarBuilder) -> Result<Self::CausalLM, BoxedError> {
+    fn build(&self, vb: VarBuilder) -> Result<Self::Architecture, BoxedError> {
         let decoder = Box::new(
             self.decoder
                 .build(vb.push_prefix("decoder"))

--- a/src/models/transformer/decoder.rs
+++ b/src/models/transformer/decoder.rs
@@ -3,7 +3,8 @@ use candle_core::{ModuleT, Tensor};
 use candle_nn::VarBuilder;
 use snafu::{ResultExt, Snafu};
 
-use crate::architectures::{BuildDecoder, BuildDecoderLayer, Decoder, DecoderLayer, DecoderOutput};
+use crate::architectures::BuildArchitecture;
+use crate::architectures::{BuildDecoderLayer, Decoder, DecoderLayer, DecoderOutput};
 use crate::error::BoxedError;
 use crate::kv_cache::{KeyValueCache, LayerKeyValueCache};
 use crate::layers::attention::AttentionMask;
@@ -57,10 +58,10 @@ impl TransformerDecoderConfig {
     }
 }
 
-impl BuildDecoder for TransformerDecoderConfig {
-    type Decoder = TransformerDecoder;
+impl BuildArchitecture for TransformerDecoderConfig {
+    type Architecture = TransformerDecoder;
 
-    fn build(&self, vb: VarBuilder) -> Result<TransformerDecoder, BoxedError> {
+    fn build(&self, vb: VarBuilder) -> Result<Self::Architecture, BoxedError> {
         let embeddings = self
             .embeddings
             .build(vb.push_prefix("embeddings"))


### PR DESCRIPTION
This trait is more general than `BuildDecoder`/`BuildCausalLM` and is introduced to accomodate HF Hub model loading. `BuildDecoder` and `BuildCausalLM` are defined it terms of `BuildArchitecture`.