### PR TITLE
Add infrastructure for Hugging Face transformers models

### DIFF
--- a/src/models/hf/checkpoint.rs
+++ b/src/models/hf/checkpoint.rs
@@ -1,0 +1,150 @@
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io;
+use std::io::BufReader;
+use std::path::{Path, PathBuf};
+
+use candle_core::safetensors::MmapedSafetensors;
+use candle_nn::var_builder::SimpleBackend;
+use serde::Deserialize;
+use snafu::{ensure, ResultExt, Snafu};
+
+use crate::error::BoxedError;
+use crate::repository::repo::Repo;
+
+static SAFETENSORS_INDEX: &str = "model.safetensors.index.json";
+static SAFETENSORS_SINGLE: &str = "model.safetensors";
+
+/// Extension trait for HF transformers checkpoint loading.
+///
+/// This trait has a single implementation that adds support to `Repo` for
+/// loading Hugging Face transformers-style checkpoints from a repository.
+pub trait LoadHFCheckpoint {
+    /// Load a Hugging Face transformers checkpoint.
+    fn load_hf_checkpoint(&self) -> Result<Box<dyn SimpleBackend>, BoxedError>;
+}
+
+/// HF transformers checkpoint loading errors.
+#[derive(Debug, Snafu)]
+pub enum HFCheckpointError {
+    #[snafu(display("Cannot download checkpoint: {name}"))]
+    Download { source: BoxedError, name: String },
+
+    #[snafu(display("Cannot open or load checkpoint"))]
+    LoadCheckpoint { source: candle_core::Error },
+
+    #[snafu(display("Checkpoint does not exist: {}", name))]
+    NonExistentCheckpoint { name: String },
+
+    #[snafu(display("Shard does not exist: {}", name))]
+    NonExistentShard { name: String },
+
+    #[snafu(display("Cannot open SafeTensors index file: {}", path.to_string_lossy()))]
+    OpenSafeTensorsIndex { source: io::Error, path: PathBuf },
+
+    #[snafu(display("Cannot parse SafeTensors index file: {}", path.to_string_lossy()))]
+    ParseSafeTensorsIndex {
+        source: serde_json::Error,
+        path: PathBuf,
+    },
+}
+
+impl<R> LoadHFCheckpoint for R
+where
+    R: Repo,
+{
+    fn load_hf_checkpoint(&self) -> Result<Box<dyn SimpleBackend>, BoxedError> {
+        self.load_safetensors()
+    }
+}
+
+/// Private trait for loading safetensors checkpoint.
+///
+/// This trait is used to load a safetensors checkpoint from the repository.
+/// We just use it so that we can implement these methods on `Repo` rather
+/// than having them as standalone functions.
+trait LoadHFSafeTensors {
+    fn load_safetensors(&self) -> Result<Box<dyn SimpleBackend>, BoxedError>;
+
+    fn load_safetensors_multi(&self, index_path: &Path) -> Result<Vec<PathBuf>, BoxedError>;
+
+    fn load_safetensors_single(&self) -> Result<Vec<PathBuf>, BoxedError>;
+}
+
+impl<R> LoadHFSafeTensors for R
+where
+    R: Repo,
+{
+    /// Load a safetensors checkpoint.
+    ///
+    /// This method will first probe if there is a shard index. If there is,
+    /// a sharded checkpoint will be loaded. Otherwise, a single-file
+    /// checkpoint is loaded.
+    fn load_safetensors(&self) -> Result<Box<dyn SimpleBackend>, BoxedError> {
+        let file = self.file(SAFETENSORS_INDEX).context(DownloadSnafu {
+            name: SAFETENSORS_INDEX,
+        })?;
+
+        let paths = match file {
+            // We have a safetensor index, so load from shards.
+            Some(index_path) => self.load_safetensors_multi(&index_path),
+
+            // No index file, so assume that there is a single checkpoint.
+            None => self.load_safetensors_single(),
+        }?;
+
+        Ok(Box::new(unsafe {
+            MmapedSafetensors::multi(&paths).context(LoadCheckpointSnafu)?
+        }))
+    }
+
+    /// Load sharded safetensors checkpoint.
+    fn load_safetensors_multi(&self, index_path: &Path) -> Result<Vec<PathBuf>, BoxedError> {
+        // Parse the shard index.
+        let index_file = BufReader::new(
+            File::open(index_path).context(OpenSafeTensorsIndexSnafu { path: index_path })?,
+        );
+        let index: SafeTensorsIndex = serde_json::from_reader(index_file)
+            .context(ParseSafeTensorsIndexSnafu { path: index_path })?;
+
+        let shard_names = index.shards();
+        let mut shards = Vec::with_capacity(shard_names.len());
+        for shard_name in shard_names {
+            let path = self.file(&shard_name).context(DownloadSnafu {
+                name: shard_name.clone(),
+            })?;
+            ensure!(path.is_some(), NonExistentShardSnafu { name: shard_name });
+            shards.push(path.unwrap());
+        }
+
+        Ok(shards)
+    }
+
+    /// Load non-sharded safetensors checkpoint.
+    fn load_safetensors_single(&self) -> Result<Vec<PathBuf>, BoxedError> {
+        let path = self.file(SAFETENSORS_SINGLE).context(DownloadSnafu {
+            name: SAFETENSORS_SINGLE,
+        })?;
+
+        ensure!(
+            path.is_some(),
+            NonExistentCheckpointSnafu {
+                name: SAFETENSORS_SINGLE.to_string(),
+            }
+        );
+
+        Ok(vec![path.unwrap()])
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SafeTensorsIndex {
+    weight_map: HashMap<String, String>,
+}
+
+impl SafeTensorsIndex {
+    /// Get the names of the shards.
+    fn shards(&self) -> HashSet<String> {
+        self.weight_map.values().cloned().collect()
+    }
+}

--- a/src/models/hf/from_hf.rs
+++ b/src/models/hf/from_hf.rs
@@ -1,0 +1,95 @@
+use candle_core::{DType, Device};
+use candle_nn::var_builder::SimpleBackend;
+use candle_nn::VarBuilder;
+use serde::{Deserialize, Serialize};
+use snafu::{ResultExt, Snafu};
+
+use crate::architectures::BuildArchitecture;
+use crate::error::BoxedError;
+use crate::util::renaming_backend::RenamingBackend;
+
+#[derive(Debug, Snafu)]
+pub enum FromHFError {
+    #[snafu(display("Cannot convert Hugging Face model config"))]
+    ConvertConfig { source: BoxedError },
+
+    #[snafu(display("Cannot build model"))]
+    BuildModel { source: BoxedError },
+}
+
+/// Models that can be loaded from Huggingface transformers checkpoints.
+pub trait FromHF {
+    /// Model configuration.
+    type Config: BuildArchitecture<Architecture = Self::Model>
+        + TryFrom<Self::HFConfig, Error = BoxedError>;
+
+    /// HF transformers model configuration.
+    type HFConfig: Clone;
+
+    /// The type of model that is constructed.
+    ///
+    /// Note that this is different from `Self`. `Self` is typically a
+    /// unit struct that only implements various loading strategies.
+    /// `Model` is a concrete model type such as `TransformerDecoder`.
+    type Model;
+
+    /// Construct a model from an HF model configuration and parameter backend.
+    ///
+    /// * `hf_config` - The Hugging Face transformers model configuration.
+    /// * `backend` - The parameter store backend.
+    /// * `device` - The device to place the model on.
+    fn from_hf(
+        hf_config: HFConfigWithDType<Self::HFConfig>,
+        backend: Box<dyn SimpleBackend>,
+        device: Device,
+    ) -> Result<Self::Model, FromHFError> {
+        // Ideally we would not clone here, but TryFrom<&...> adds a lot of
+        // pesky lifetime annotations everywhere.
+        let config =
+            Self::Config::try_from(hf_config.config().clone()).context(ConvertConfigSnafu)?;
+        let rename_backend = RenamingBackend::new(backend, Self::rename_parameters());
+        let vb = VarBuilder::from_backend(Box::new(rename_backend), hf_config.dtype(), device);
+        config.build(vb).context(BuildModelSnafu)
+    }
+
+    /// Create a parameter renaming function.
+    ///
+    /// This method should return a function that renames Oxidized Transformers
+    /// parameter names to Hugging Face transformers parameter names.
+    fn rename_parameters() -> impl Fn(&str) -> String + Send + Sync;
+}
+
+/// Torch dtype
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum TorchDType {
+    BFloat16,
+    Float16,
+    Float32,
+}
+
+/// Simple wrapper for a HF config that exposes the dtype.
+#[non_exhaustive]
+#[derive(Debug, Clone, Copy, Deserialize, Eq, PartialEq)]
+pub struct HFConfigWithDType<T> {
+    #[serde(flatten)]
+    config: T,
+    torch_dtype: TorchDType,
+}
+
+impl<T> HFConfigWithDType<T> {
+    /// Get the configuration.
+    pub fn config(&self) -> &T {
+        &self.config
+    }
+
+    /// Get the dtype.
+    pub fn dtype(&self) -> DType {
+        match self.torch_dtype {
+            TorchDType::BFloat16 => DType::BF16,
+            TorchDType::Float16 => DType::F16,
+            TorchDType::Float32 => DType::F32,
+        }
+    }
+}

--- a/src/models/hf/hf_hub.rs
+++ b/src/models/hf/hf_hub.rs
@@ -1,0 +1,87 @@
+use std::fs::File;
+use std::path::PathBuf;
+
+use candle_core::Device;
+use hf_hub::api::sync::ApiError;
+use serde::de::DeserializeOwned;
+use snafu::{ResultExt, Snafu};
+
+use crate::error::BoxedError;
+use crate::models::hf::checkpoint::LoadHFCheckpoint;
+use crate::models::hf::from_hf::{FromHF, FromHFError};
+use crate::models::hf::HFConfigWithDType;
+use crate::repository::hf_hub::HfHubRepo;
+use crate::repository::repo::Repo;
+
+/// Errors for loading a model from Hugging Face Hub.
+#[derive(Debug, Snafu)]
+pub enum FromHfHubError {
+    #[snafu(display("Model configuration file does not exist"))]
+    ConfigPath,
+
+    #[snafu(display("Cannot convert Hugging Face model"))]
+    FromHF { source: FromHFError },
+
+    #[snafu(display("Hugging Face Hub error"))]
+    HFHub { source: ApiError },
+
+    #[snafu(display("Hugging Face Hub repository error"))]
+    HFHubRepo { source: BoxedError },
+
+    #[snafu(display("Cannot deserialize JSON"))]
+    JSON { source: serde_json::Error },
+
+    #[snafu(display("Cannot open or load checkpoint"))]
+    LoadCheckpoint { source: BoxedError },
+
+    #[snafu(display("Cannot open file for reading: {path:?}"))]
+    Open {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+/// Trait for loading models from Hugging Face Hub.
+pub trait FromHFHub
+where
+    Self: Sized,
+{
+    type Model;
+
+    /// Load a model from Hugging Face Hub.
+    ///
+    /// * `name` - Model repository name.
+    /// * `revision` - Model revision. If `None`, the main branch is used.
+    /// * `device` - The device to place the model on.
+    fn from_hf_hub(
+        name: &str,
+        revision: Option<&str>,
+        device: Device,
+    ) -> Result<Self::Model, FromHfHubError>;
+}
+
+impl<HF, C, HC> FromHFHub for HF
+where
+    HF: FromHF<Config = C, HFConfig = HC>,
+    HC: DeserializeOwned,
+    C: TryFrom<HC, Error = BoxedError>,
+{
+    type Model = HF::Model;
+
+    fn from_hf_hub(
+        name: &str,
+        revision: Option<&str>,
+        device: Device,
+    ) -> Result<Self::Model, FromHfHubError> {
+        let repo = HfHubRepo::new(name, revision).context(HFHubRepoSnafu)?;
+        let config_file = repo.file("config.json").context(HFHubRepoSnafu)?;
+        let config_path = config_file.ok_or(FromHfHubError::ConfigPath)?;
+        let config_file = File::open(&config_path).context(OpenSnafu { path: config_path })?;
+        let hf_config: HFConfigWithDType<HC> =
+            serde_json::from_reader(&config_file).context(JSONSnafu)?;
+
+        let backend = repo.load_hf_checkpoint().context(LoadCheckpointSnafu)?;
+
+        Self::from_hf(hf_config, backend, device).context(FromHFSnafu)
+    }
+}

--- a/src/models/hf/mod.rs
+++ b/src/models/hf/mod.rs
@@ -1,0 +1,9 @@
+/// Load Hugging Face transformers checkpoints.
+mod checkpoint;
+pub use checkpoint::{HFCheckpointError, LoadHFCheckpoint};
+
+mod from_hf;
+pub use from_hf::{FromHF, FromHFError, HFConfigWithDType};
+
+mod hf_hub;
+pub use hf_hub::{FromHFHub, FromHfHubError};

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,1 +1,3 @@
+pub mod hf;
+
 pub mod transformer;


### PR DESCRIPTION
This change bundles a few related changes for model loading:

- Add the `LoadHFCheckpoint` trait and provide an implementation for `Repository`. The implementation can currently load SafeTensors checkpoints and sharded SafeTensors checkpoints.
- Add the `FromHF` trait. This is implemented by models that are added in future PRs.
- Add the `FromHFHub` trait and implement it for all types that implement `FromHF` and uses `LoadHFCheckpoint`.
- Relax the typing in `RenamingBackend` a little through boxing to make it easier to use in downstream code.