### PR TITLE
Traitify embeddings

### DIFF
--- a/src/architectures/embeddings.rs
+++ b/src/architectures/embeddings.rs
@@ -1,0 +1,30 @@
+use candle_core::Tensor;
+use candle_nn::VarBuilder;
+use std::fmt::Debug;
+
+use crate::error::BoxedError;
+
+/// Trait for embedding layers.
+pub trait Embeddings {
+    /// Look up the embeddings for the given piece identifiers.
+    ///
+    /// * `piece_ids` - Piece identifiers.
+    ///   *Shape:* `(batch_size, seq_len)`
+    /// * `train` - Whether to train the layer.
+    /// * `positions` - Input positions.
+    ///   *Shape:* `(batch_size, seq_len)`
+    /// * `type_ids` - Input type identifiers.
+    ///   *Shape:* `(batch_size, seq_len)`
+    fn forward(
+        &self,
+        piece_ids: &Tensor,
+        train: bool,
+        positions: Option<&Tensor>,
+        type_ids: Option<&Tensor>,
+    ) -> Result<Tensor, BoxedError>;
+}
+
+/// Trait for building embedding layers.
+pub trait BuildEmbeddings: Debug {
+    fn build(&self, vb: VarBuilder) -> Result<Box<dyn Embeddings>, BoxedError>;
+}

--- a/src/architectures/mod.rs
+++ b/src/architectures/mod.rs
@@ -10,7 +10,11 @@ pub use decoder::{BuildDecoder, BuildDecoderLayer, Decoder, DecoderLayer, Decode
 mod encoder;
 pub use encoder::{BuildEncoderLayer, EncoderLayer, EncoderOutput};
 
+mod embeddings;
+pub use embeddings::{BuildEmbeddings, Embeddings};
+
 mod output;
+
 use crate::error::BoxedError;
 pub use output::LayerOutputs;
 


### PR DESCRIPTION
This change introduces the `Embeddings`/`BuildEmbeddings` traits, in preparation of the RoBERTa model, which uses its own embedding layer.

Also fix the embedding projection, which erroneously used the `Embedding` module rather than the `Linear` module.