### PR TITLE
Add `LlamaDecoder`/`LlamaCausalLM`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,9 @@ homepage = "https://github.com/danieldk/oxidized-transformers"
 [dependencies]
 candle-core = { git = "https://github.com/huggingface/candle.git", rev = "a90fc5c" }
 candle-nn = { git = "https://github.com/huggingface/candle.git", rev = "a90fc5c" }
-snafu = "0.8"
 hf-hub = "0.3"
+regex = "1.10"
+snafu = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokenizers = { version = "0.15", features = ["http"] }
@@ -19,3 +20,5 @@ tokenizers = { version = "0.15", features = ["http"] }
 approx = "0.5"
 rstest = "0.18"
 ndarray = { version = "0.15.4", features = ["approx-0_5"] }
+rand_pcg = "0.3"
+rand_core = "0.6"

--- a/src/models/llama/causal_lm.rs
+++ b/src/models/llama/causal_lm.rs
@@ -1,0 +1,115 @@
+use serde::{Deserialize, Serialize};
+
+use crate::error::BoxedError;
+use crate::models::hf::FromHF;
+use crate::models::llama::decoder::HFLlamaDecoderConfig;
+use crate::models::llama::LlamaDecoder;
+use crate::models::transformer::{
+    TransformerCausalLM, TransformerCausalLMConfig, TransformerDecoderConfig,
+};
+
+/// Llama causal language model (Touvron et al., 2023).
+///
+/// See:
+/// * [LLaMA: Open and Efficient Foundation Language Models](https://arxiv.org/abs/2302.13971)
+/// * [Llama 2: Open Foundation and Fine-Tuned Chat Models](https://arxiv.org/abs/2307.09288)
+pub struct LlamaCausalLM;
+
+/// Llama causal language model configuration.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct HfLlamaCausalLMConfig {
+    #[serde(flatten)]
+    decoder: HFLlamaDecoderConfig,
+}
+
+impl TryFrom<HfLlamaCausalLMConfig> for TransformerCausalLMConfig {
+    type Error = BoxedError;
+
+    fn try_from(config: HfLlamaCausalLMConfig) -> Result<Self, Self::Error> {
+        Ok(Self::default()
+            .hidden_size(config.decoder.hidden_size)
+            // Input and output vocab sizes are the same.
+            .n_pieces(config.decoder.vocab_size)
+            .decoder(Box::new(TransformerDecoderConfig::try_from(
+                config.decoder,
+            )?)))
+    }
+}
+
+impl FromHF for LlamaCausalLM {
+    type Config = TransformerCausalLMConfig;
+
+    type HFConfig = HfLlamaCausalLMConfig;
+
+    type Model = TransformerCausalLM;
+
+    fn rename_parameters() -> impl Fn(&str) -> String {
+        LlamaDecoder::rename_parameters()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use candle_core::{Device, Tensor};
+    use ndarray::array;
+    use snafu::{report, FromString, ResultExt, Whatever};
+
+    use crate::architectures::CausalLM;
+    use crate::kv_cache::KeyValueCache;
+    use crate::layers::attention::AttentionMask;
+    use crate::models::hf::FromHFHub;
+    use crate::models::llama::causal_lm::LlamaCausalLM;
+    use crate::util::tests::{assert_tensor_eq, PseudoRandomReduction};
+
+    fn sample_inputs() -> Result<(Tensor, Tensor), Whatever> {
+        let input = Tensor::arange(0i64, 24, &Device::Cpu)
+            .and_then(|t| t.reshape((3, 8)))
+            .with_whatever_context(|_| "Cannot create input tensor")?;
+
+        let mask = Tensor::from_slice(
+            &[
+                1u32, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 0, 0, 1, 1, 0,
+            ],
+            (3, 8),
+            &Device::Cpu,
+        )
+        .with_whatever_context(|_| "Cannot create attention mask tensor")?;
+
+        Ok((input, mask))
+    }
+
+    #[test]
+    #[report]
+    fn llama_causal_lm_emits_correct_output() -> Result<(), Whatever> {
+        let causal_lm =
+            LlamaCausalLM::from_hf_hub("explosion-testing/llama2-kv-sharing", None, Device::Cpu)
+                .whatever_context("Cannot load model")?;
+
+        let (input, mask) = sample_inputs()?;
+
+        let output = causal_lm
+            .forward_t(
+                &input,
+                &AttentionMask::new(mask).unwrap(),
+                &mut KeyValueCache::no_cache(5),
+                None,
+                false,
+            )
+            .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))?;
+
+        assert_tensor_eq::<f32>(
+            output
+                .logits()
+                .pseudo_random_reduction()
+                .whatever_context("Cannot apply reduction using random vector")?,
+            array![
+                [0.0000, -0.7422, 3.9272, 2.4643, 1.2032, -0.2746, 0.0612, 2.6404],
+                [-1.6657, -1.5350, -0.9877, 0.1828, 0.2311, 0.7174, 0.4477, -0.4943],
+                [-1.4341, -2.5877, -1.4347, -1.1339, -1.8117, -0.2561, -0.6859, -2.5824]
+            ],
+            1e-4,
+        );
+
+        Ok(())
+    }
+}

--- a/src/models/llama/decoder.rs
+++ b/src/models/llama/decoder.rs
@@ -1,0 +1,274 @@
+use std::sync::OnceLock;
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+
+use crate::error::BoxedError;
+use crate::layers::activation::Activation;
+use crate::layers::attention::{AttentionHeads, QkvMode, SelfAttentionConfig};
+use crate::layers::embeddings::QueryKeyRotaryEmbeddingsConfig;
+use crate::layers::feedforward::PointwiseFeedForwardConfig;
+use crate::layers::layer_norm::RMSNormConfig;
+use crate::layers::transformer::{TransformerEmbeddingsConfig, TransformerLayerConfig};
+use crate::models::hf::FromHF;
+use crate::models::transformer::{TransformerDecoder, TransformerDecoderConfig};
+
+/// Llama decoder (Touvron et al., 2023).
+///
+/// See:
+/// * [LLaMA: Open and Efficient Foundation Language Models](https://arxiv.org/abs/2302.13971)
+/// * [Llama 2: Open Foundation and Fine-Tuned Chat Models](https://arxiv.org/abs/2307.09288)
+pub struct LlamaDecoder;
+
+/// HF Llama model types
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HfModelType {
+    Llama,
+}
+
+/// Hf Llama decoder configuration.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct HFLlamaDecoderConfig {
+    hidden_act: Activation,
+    pub(crate) hidden_size: usize,
+    initializer_range: f32,
+    intermediate_size: usize,
+    max_position_embeddings: usize,
+    model_type: HfModelType,
+    num_attention_heads: usize,
+    num_hidden_layers: usize,
+    num_key_value_heads: usize,
+    rms_norm_eps: f32,
+    tie_word_embeddings: bool,
+    pub(crate) vocab_size: usize,
+}
+
+impl TryFrom<HFLlamaDecoderConfig> for TransformerDecoderConfig {
+    type Error = BoxedError;
+
+    fn try_from(hf_config: HFLlamaDecoderConfig) -> Result<Self, Self::Error> {
+        let layer_norm = Box::new(
+            RMSNormConfig::default()
+                .eps(hf_config.rms_norm_eps as f64)
+                .size(hf_config.hidden_size),
+        );
+
+        let embeddings = TransformerEmbeddingsConfig::default()
+            .embedding_width(hf_config.hidden_size)
+            .hidden_width(hf_config.hidden_size)
+            .n_pieces(hf_config.vocab_size);
+
+        let feedforward = PointwiseFeedForwardConfig::default()
+            .activation(Box::new(hf_config.hidden_act))
+            .hidden_width(hf_config.hidden_size)
+            .intermediate_width(hf_config.intermediate_size)
+            .layer_norm(layer_norm.clone())
+            .use_bias(false)
+            .use_gate(true);
+
+        let attention = SelfAttentionConfig::default()
+            .attention_heads(AttentionHeads {
+                n_query_heads: hf_config.num_attention_heads,
+                n_key_value_heads: hf_config.num_key_value_heads,
+                qkv_mode: QkvMode::Separate,
+            })
+            .hidden_width(hf_config.hidden_size)
+            .layer_norm(layer_norm.clone())
+            .rotary_embeddings(Some(
+                QueryKeyRotaryEmbeddingsConfig::default()
+                    .head_width(hf_config.hidden_size / hf_config.num_attention_heads)
+                    .seq_len(hf_config.max_position_embeddings),
+            ));
+
+        let layer = TransformerLayerConfig::default()
+            .attention(attention)
+            .feedforward(feedforward);
+
+        Ok(TransformerDecoderConfig::default()
+            .embeddings(embeddings)
+            .layer(Box::new(layer))
+            .n_hidden_layers(hf_config.num_hidden_layers)
+            .output_layer_norm(layer_norm))
+    }
+}
+
+impl FromHF for LlamaDecoder {
+    type Config = TransformerDecoderConfig;
+
+    type HFConfig = HFLlamaDecoderConfig;
+
+    type Model = TransformerDecoder;
+
+    fn rename_parameters() -> impl Fn(&str) -> String {
+        |name| {
+            let mut name = if name.starts_with("decoder.") {
+                name.replace("decoder.", "model.")
+            } else if !name.starts_with("output_embeddings") {
+                format!("model.{name}")
+            } else {
+                name.to_string()
+            };
+            name = name.replace("embeddings.piece_embeddings", "embed_tokens");
+
+            // Attention layer.
+            name = name.replace("attention.query", "attention.q_proj");
+            name = name.replace("attention.key", "attention.k_proj");
+            name = name.replace("attention.value", "attention.v_proj");
+            name = name.replace("attention.output", "attention.o_proj");
+            name = name.replace("attention.layer_norm", "input_layernorm");
+            name = name.replace("attention.", "self_attn.");
+
+            // Feed-forward layer.
+            name = name.replace("ffn.layer_norm", "post_attention_layernorm");
+            name = name.replace("ffn.output", "ffn.down_proj");
+            name = name.replace("ffn.", "mlp.");
+            name = name.replace("intermediate", "up_proj");
+            name = name.replace("gate", "gate_proj");
+
+            // Layer norm after all layers.
+            name = name.replace("output_layer_norm", "norm");
+
+            // Output vocab.
+            name = name.replace("output_embeddings", "lm_head");
+
+            static LAYER_RE: OnceLock<Regex> = OnceLock::new();
+            let layer_re =
+                LAYER_RE.get_or_init(|| Regex::new(r"layer_(\d+)").expect("Invalid regex"));
+            name = layer_re.replace(&name, "layers.$1").to_string();
+            name
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use candle_core::{DType, Device, Tensor};
+    use ndarray::array;
+    use snafu::{report, FromString, ResultExt, Whatever};
+
+    use crate::architectures::{Decoder, LayerOutputs};
+    use crate::kv_cache::KeyValueCache;
+    use crate::layers::attention::AttentionMask;
+    use crate::models::hf::FromHFHub;
+    use crate::models::llama::LlamaDecoder;
+    use crate::util::tests::{assert_tensor_eq, PseudoRandomReduction};
+
+    fn sample_inputs() -> Result<(Tensor, Tensor), Whatever> {
+        let input = Tensor::arange(0i64, 24, &Device::Cpu)
+            .and_then(|t| t.reshape((3, 8)))
+            .with_whatever_context(|_| "Cannot create input tensor")?;
+
+        let mask = Tensor::from_slice(
+            &[
+                1u32, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 0, 0, 1, 1, 0,
+            ],
+            (3, 8),
+            &Device::Cpu,
+        )
+        .with_whatever_context(|_| "Cannot create attention mask tensor")?;
+
+        Ok((input, mask))
+    }
+
+    #[test]
+    #[report]
+    fn llama_decoder_emits_correct_output() -> Result<(), Whatever> {
+        let decoder =
+            LlamaDecoder::from_hf_hub("explosion-testing/llama2-kv-sharing", None, Device::Cpu)
+                .with_whatever_context(|_| "Cannot load model")?;
+
+        let (input, mask) = sample_inputs()?;
+
+        let output = decoder
+            .forward_t(
+                &input,
+                &AttentionMask::new(mask).whatever_context("Cannot build attention mask")?,
+                &mut KeyValueCache::no_cache(5),
+                None,
+                false,
+            )
+            .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))?;
+
+        let last_output = output.layer_outputs().last().unwrap();
+
+        assert_tensor_eq::<f32>(
+            last_output
+                .pseudo_random_reduction()
+                .whatever_context("Cannot apply reduction using random vector")?,
+            array![
+                [0.0000, -0.7430, -5.4662, -6.5113, -7.6470, -12.3254, -7.7909, -7.3655],
+                [-9.9933, -10.4256, -10.3813, -12.0933, -12.3758, -17.6279, -17.4024, -11.2087],
+                [-1.7355, 1.8150, 2.2124, 1.4387, 1.2247, 1.7853, -0.4188, -1.9727]
+            ],
+            1e-4,
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    #[report]
+    fn llama_decoder_give_correct_output_with_cache() -> Result<(), Whatever> {
+        let decoder =
+            LlamaDecoder::from_hf_hub("explosion-testing/llama2-kv-sharing", None, Device::Cpu)
+                .with_whatever_context(|_| "Cannot load model")?;
+
+        let (input, mask) = sample_inputs()?;
+
+        let mut cache =
+            KeyValueCache::cache(input.shape().dims()[0], 64, 1, 5, DType::F32, &Device::Cpu)
+                .whatever_context("Cannot create cache")?;
+        let attention_mask = AttentionMask::new(
+            mask.narrow(1, 0, 7)
+                .whatever_context("Cannot slice attention mask")?,
+        )
+        .whatever_context("Cannot build attention mask")?;
+
+        let _ = decoder
+            .forward_t(
+                &input
+                    .narrow(1, 0, 7)
+                    .whatever_context("Cannot slice input")?,
+                &attention_mask,
+                &mut cache,
+                None,
+                false,
+            )
+            .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))?;
+
+        let attention_mask = attention_mask
+            .extend(
+                &AttentionMask::new(
+                    mask.narrow(1, 7, 1)
+                        .whatever_context("Cannot slice attention mask")?,
+                )
+                .whatever_context("Cannot build attention mask")?,
+            )
+            .whatever_context("Cannot extend attention mask")?;
+
+        let output = decoder
+            .forward_t(
+                &input
+                    .narrow(1, 7, 1)
+                    .whatever_context("Cannot slice input")?,
+                &attention_mask,
+                &mut cache,
+                None,
+                false,
+            )
+            .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))?;
+
+        let last_output = output.layer_outputs().last().unwrap();
+
+        assert_tensor_eq::<f32>(
+            last_output
+                .pseudo_random_reduction()
+                .whatever_context("Cannot apply reduction using random vector")?,
+            array![[-7.3655], [-11.2087], [-1.9727]],
+            1e-4,
+        );
+
+        Ok(())
+    }
+}

--- a/src/models/llama/mod.rs
+++ b/src/models/llama/mod.rs
@@ -1,0 +1,6 @@
+//! Llama architectures (Touvron et al., 2023).
+mod causal_lm;
+pub use causal_lm::LlamaCausalLM;
+
+mod decoder;
+pub use decoder::LlamaDecoder;

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,6 @@
 pub mod hf;
 
+mod llama;
+pub use llama::{LlamaCausalLM, LlamaDecoder};
+
 pub mod transformer;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -6,8 +6,11 @@ pub(crate) mod tests {
     use std::fmt::Debug;
 
     use approx::{assert_abs_diff_eq, AbsDiffEq};
-    use candle_core::{Tensor, WithDType};
+    use candle_core::{Device, Tensor, WithDType, D};
     use ndarray::{ArrayBase, ArrayD, DataOwned, Dimension};
+    use rand_core::RngCore;
+    use rand_pcg::Pcg32;
+    use snafu::{ResultExt, Snafu};
 
     // Like TryInto, but we need our own trait so that we can implement it
     // for external types.
@@ -61,5 +64,76 @@ pub(crate) mod tests {
         );
 
         assert_abs_diff_eq!(a, b, epsilon = epsilon);
+    }
+
+    /// Generate vectors with a PRNG.
+    trait PseudoRandom {
+        /// Generate a vector with a PRNG.
+        ///
+        /// This method generates a vector with the given length. The seed of
+        /// the PRNG is set to the given length.
+        ///
+        /// * `len` - The length of the vector to generate.
+        /// * `device` - The device to allocate the tensor on.
+        fn pseudo_random(len: usize, device: &Device) -> Self;
+    }
+
+    impl PseudoRandom for Tensor {
+        fn pseudo_random(len: usize, device: &Device) -> Self {
+            let mut rng = Pcg32::new(len as u64, 0);
+            let iter = (0..len).map(|_| {
+                let next = rng.next_u32();
+
+                // Generate a uniform random number in [0, 1). We don't use
+                // rand's uniform sampler, because we want full control over
+                // the sampling. This allows us to mirror the sampling in
+                // Python-land for getting test vectors and test vectors don't
+                // get invalidated by changes in the rand crate.
+                let mantissa_bits_shift = u32::BITS - f32::MANTISSA_DIGITS;
+                let zero_one =
+                    (next >> mantissa_bits_shift) as f32 / (1 << f32::MANTISSA_DIGITS) as f32;
+
+                // We have not used the least significant bit while generating
+                // the random number, so we can use it to pick the sign.
+                let sign = (next & 1) as f32;
+                zero_one - sign
+            });
+            Tensor::from_iter(iter, device).expect("Cannot allocate random tensor")
+        }
+    }
+
+    #[derive(Debug, Snafu)]
+    pub enum PseudoRandomReductionError {
+        #[snafu(display("Cannot calculate matmul of tensor and random vector"))]
+        MatMul { source: candle_core::Error },
+
+        #[snafu(display("Cannot get size of last dimension, tensor is a scalar"))]
+        Scalar { source: candle_core::Error },
+
+        #[snafu(display("Cannot reshape"))]
+        Shape { source: candle_core::Error },
+    }
+
+    /// Vector reduction using pseudo-random vectors.
+    pub trait PseudoRandomReduction {
+        /// Reduce the tensor using a pseudo-random vector.
+        ///
+        /// Compute an aggregate of the last dimension of a tensor by
+        /// computing the dot product of last-dimension vectors with a
+        /// pseudo-random vector.
+        fn pseudo_random_reduction(self) -> Result<Tensor, PseudoRandomReductionError>;
+    }
+
+    impl PseudoRandomReduction for &Tensor {
+        fn pseudo_random_reduction(self) -> Result<Tensor, PseudoRandomReductionError> {
+            let size = self.dim(D::Minus1).context(ScalarSnafu)?;
+            let random = Tensor::pseudo_random(size, self.device())
+                .reshape((size, 1))
+                .context(ShapeSnafu)?;
+            self.broadcast_matmul(&random)
+                .context(MatMulSnafu)?
+                .squeeze(D::Minus1)
+                .context(ShapeSnafu)
+        }
     }
 }


### PR DESCRIPTION
This change also introduces a way of checking against aggregate test vectors in a way that is sensitive to changes in order, etc. If we take an aggregate that is based on a commutative operator, such as addition or max, changes in the
order would still result in the same aggregates.

So rather than using a simple aggregate, we use random tensors that are generated deterministically using a PRNG. Then we compute the dot product of the random vector and the output as the aggregate. Since all the elements of the random vector differ and the dot product does a pairwaise multiplication of the output and the random vector, different orders will result in different aggregates.