### PR TITLE
Snake case activations

### DIFF
--- a/src/layers/activation.rs
+++ b/src/layers/activation.rs
@@ -8,31 +8,37 @@ use crate::layers::build_module::BuildModule;
 /// Activation functions.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum Activation {
     /// Gausian Error Linear Unit.
     ///
     /// See [Hendrycks and Gimpel, 2016](https://arxiv.org/abs/1606.08415).
-    GELU,
+    Gelu,
+
+    /// Gausian Error Linear Unit approximation.
+    ///
+    /// See [Hendrycks and Gimpel, 2016](https://arxiv.org/abs/1606.08415).
+    GeluNew,
 
     /// Rectified Linear Unit.
     ///
     /// See [Fukushima, 1969](https://ieeexplore.ieee.org/document/4082265).
-    ReLU,
+    Relu,
 
     /// Sigmoid Linear Unit.
     ///
     /// See [Hendrycks and Gimpel, 2016](https://arxiv.org/abs/1606.08415).
-    SiLU,
+    Silu,
 }
 
 impl BuildModule for Activation {
     fn build(&self, _vb: VarBuilder) -> Result<Box<dyn ModuleT>, BoxedError> {
         use Activation::*;
         Ok(match self {
-            GELU => Box::new(CandleActivation::Gelu),
-            ReLU => Box::new(CandleActivation::Relu),
-            SiLU => Box::new(CandleActivation::Silu),
+            Gelu => Box::new(CandleActivation::Gelu),
+            GeluNew => Box::new(CandleActivation::NewGelu),
+            Relu => Box::new(CandleActivation::Relu),
+            Silu => Box::new(CandleActivation::Silu),
         })
     }
 }

--- a/src/layers/feedforward.rs
+++ b/src/layers/feedforward.rs
@@ -81,7 +81,7 @@ impl PointwiseFeedForwardConfig {
 impl Default for PointwiseFeedForwardConfig {
     fn default() -> Self {
         Self {
-            activation: Box::new(Activation::GELU),
+            activation: Box::new(Activation::Gelu),
             dropout: Box::new(Identity),
             hidden_width: 768,
             intermediate_width: 3072,


### PR DESCRIPTION
This is in preparation for `gelu_new`, where we cannot simply lowercase the enum variant names anymore. Also add the `GeluNew` variant (used by ALBERT).