### PR TITLE
Add `AlbertEncoder`

### DIFF
--- a/src/layers/attention/self_attention.rs
+++ b/src/layers/attention/self_attention.rs
@@ -462,16 +462,13 @@ impl SelfAttention {
         let (_, _, _, all_heads_size) = proj.shape().dims4().context(QkvSnafu)?;
         let head_size = all_heads_size / 3;
 
-        // Similar to chunk, but avoid intermediate Vec. Needs to be contiguous or
-        // matrix multiplication fails later.
+        // Similar to chunk, but avoid intermediate Vec.
         let query = proj.narrow(3, 0, head_size).context(QkvChunkSnafu)?;
         let key = proj
             .narrow(3, head_size, head_size)
             .context(QkvChunkSnafu)?;
         let value = proj
             .narrow(3, 2 * head_size, head_size)
-            // Needs to be contiguous to avoid matmul stride error.
-            .and_then(|xs| xs.contiguous())
             .context(QkvChunkSnafu)?;
 
         Ok((query, key, value))

--- a/src/models/albert/encoder.rs
+++ b/src/models/albert/encoder.rs
@@ -1,0 +1,375 @@
+use std::sync::OnceLock;
+
+use candle_core::Tensor;
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use snafu::{ensure, ResultExt, Snafu};
+
+use crate::architectures::{
+    BuildArchitecture, BuildEmbeddings, BuildEncoderLayer, Embeddings, Encoder, EncoderLayer,
+    EncoderOutput,
+};
+use crate::error::BoxedError;
+use crate::layers::activation::Activation;
+use crate::layers::attention::{
+    AttentionHeads, AttentionMask, QkvMode, ScaledDotProductAttentionConfig, SelfAttentionConfig,
+};
+use crate::layers::dropout::DropoutConfig;
+use crate::layers::feedforward::PointwiseFeedForwardConfig;
+use crate::layers::layer_norm::LayerNormConfig;
+use crate::layers::transformer::{TransformerEmbeddingsConfig, TransformerLayerConfig};
+use crate::models::albert::AlbertLayerGroupConfig;
+use crate::models::hf::FromHF;
+
+/// HF ALBERT model types
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HFModelType {
+    Albert,
+}
+
+/// HF ALBERT encoder configuration.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct HFAlbertEncoderConfig {
+    attention_probs_dropout_prob: f32,
+    embedding_size: usize,
+    hidden_act: Activation,
+    hidden_dropout_prob: f32,
+    hidden_size: usize,
+    initializer_range: f32,
+    intermediate_size: usize,
+    inner_group_num: usize,
+    layer_norm_eps: f64,
+    max_position_embeddings: usize,
+    model_type: HFModelType,
+    num_attention_heads: usize,
+    num_hidden_groups: usize,
+    num_hidden_layers: usize,
+    pad_token_id: u32,
+    type_vocab_size: usize,
+    vocab_size: usize,
+}
+
+impl TryFrom<HFAlbertEncoderConfig> for AlbertEncoderConfig {
+    type Error = BoxedError;
+
+    fn try_from(hf_config: HFAlbertEncoderConfig) -> Result<Self, Self::Error> {
+        let n_hidden_groups = hf_config.num_hidden_groups;
+        let n_hidden_layers = hf_config.num_hidden_layers;
+
+        ensure!(
+            n_hidden_layers % n_hidden_groups == 0,
+            IncorrectNHiddenGroupsSnafu {
+                n_hidden_groups,
+                n_hidden_layers
+            }
+        );
+
+        let attention_probs_dropout =
+            Box::new(DropoutConfig::default().p(hf_config.attention_probs_dropout_prob));
+        let hidden_dropout = Box::new(DropoutConfig::default().p(hf_config.hidden_dropout_prob));
+        let embedding_layer_norm = Box::new(
+            LayerNormConfig::default()
+                .eps(hf_config.layer_norm_eps)
+                .size(hf_config.embedding_size),
+        );
+        let layer_norm = Box::new(
+            LayerNormConfig::default()
+                .eps(hf_config.layer_norm_eps)
+                .size(hf_config.hidden_size),
+        );
+
+        let embeddings = TransformerEmbeddingsConfig::default()
+            .embedding_dropout(hidden_dropout.clone())
+            .embedding_layer_norm(embedding_layer_norm)
+            .embedding_width(hf_config.embedding_size)
+            .hidden_width(hf_config.hidden_size)
+            .n_pieces(hf_config.vocab_size)
+            .n_positions(Some(hf_config.max_position_embeddings))
+            .n_types(Some(hf_config.type_vocab_size));
+
+        let attention = SelfAttentionConfig::default()
+            .attention_heads(AttentionHeads {
+                n_query_heads: hf_config.num_attention_heads,
+                n_key_value_heads: hf_config.num_attention_heads,
+                qkv_mode: QkvMode::Separate,
+            })
+            .attention_scorer(Box::new(
+                ScaledDotProductAttentionConfig::default().dropout(attention_probs_dropout),
+            ))
+            .hidden_width(hf_config.hidden_size);
+
+        let feedforward = PointwiseFeedForwardConfig::default()
+            .activation(Box::new(hf_config.hidden_act))
+            .dropout(hidden_dropout)
+            .hidden_width(hf_config.hidden_size)
+            .intermediate_width(hf_config.intermediate_size);
+
+        let layer = AlbertLayerGroupConfig::default()
+            .n_layers_per_group(hf_config.inner_group_num)
+            .transformer_layer(
+                TransformerLayerConfig::default()
+                    .attention(attention)
+                    .attn_residual_layer_norm(layer_norm.clone())
+                    .feedforward(feedforward)
+                    .ffn_residual_layer_norm(layer_norm),
+            );
+
+        Ok(Self::default()
+            .embeddings(Box::new(embeddings))
+            .layer_group(Box::new(layer))
+            .n_hidden_groups(n_hidden_groups)
+            .n_hidden_layers(n_hidden_layers))
+    }
+}
+
+/// ALBERT encoder configuration.
+///
+/// Configuration for [AlbertEncoder]. ALBERT differs from an encoder like
+/// BERT in two ways:
+///
+/// 1. The embedding size can be different from the hidden size. A projection
+///    matrix is used when the sizes differ.
+/// 2. A group of layers can share parameters. For instance, if the number of
+///    layers (`n_hidden_layers`) is 12 and the number of groups (`n_hidden_groups`)
+///    is 4, then layers 0..3, 3..6, 6..9, and 9..12 will share parameters.
+#[derive(Debug)]
+pub struct AlbertEncoderConfig {
+    embeddings: Box<dyn BuildEmbeddings>,
+    layer_group: Box<dyn BuildEncoderLayer>,
+    n_hidden_groups: usize,
+    n_hidden_layers: usize,
+}
+
+impl AlbertEncoderConfig {
+    /// Encoder embeddings.
+    ///
+    /// Default: `TransformerEmbeddingsConfig::default()`
+    pub fn embeddings(mut self, embeddings: Box<dyn BuildEmbeddings>) -> Self {
+        self.embeddings = embeddings;
+        self
+    }
+
+    /// Number of layers within a group.
+    ///
+    /// Default: `AlbertLayerGroupConfig::default()`
+    pub fn layer_group(mut self, layer_group: Box<dyn BuildEncoderLayer>) -> Self {
+        self.layer_group = layer_group;
+        self
+    }
+
+    /// Number of hidden groups.
+    ///
+    /// Default: `1`
+    pub fn n_hidden_groups(mut self, n_hidden_groups: usize) -> Self {
+        self.n_hidden_groups = n_hidden_groups;
+        self
+    }
+
+    /// Number of hidden layers.
+    ///
+    /// Default: `12`
+    pub fn n_hidden_layers(mut self, n_hidden_layers: usize) -> Self {
+        self.n_hidden_layers = n_hidden_layers;
+        self
+    }
+}
+
+impl Default for AlbertEncoderConfig {
+    fn default() -> Self {
+        Self {
+            embeddings: Box::<TransformerEmbeddingsConfig>::default(),
+            layer_group: Box::<AlbertLayerGroupConfig>::default(),
+            n_hidden_groups: 1,
+            n_hidden_layers: 12,
+        }
+    }
+}
+
+impl BuildArchitecture for AlbertEncoderConfig {
+    type Architecture = AlbertEncoder;
+
+    fn build(&self, vb: candle_nn::VarBuilder) -> Result<Self::Architecture, BoxedError> {
+        let embeddings = self
+            .embeddings
+            .build(vb.push_prefix("embeddings"))
+            .context(BuildEmbeddingsSnafu)?;
+
+        let groups = (0..self.n_hidden_groups)
+            .map(|n| {
+                self.layer_group
+                    .build_encoder_layer(vb.push_prefix(format!("group_{n}")))
+                    .context(BuildLayerGroupSnafu { n })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(AlbertEncoder {
+            embeddings,
+            groups,
+            n_hidden_layers: self.n_hidden_layers,
+        })
+    }
+}
+
+/// ALBERT encoder errors.
+#[derive(Debug, Snafu)]
+enum AlbertEncoderError {
+    #[snafu(display("Cannot build layer group {n}"))]
+    BuildLayerGroup { source: BoxedError, n: usize },
+
+    #[snafu(display("Cannot build embeddings"))]
+    BuildEmbeddings { source: BoxedError },
+
+    #[snafu(display("Cannot apply embeddings"))]
+    Embeddings { source: BoxedError },
+
+    #[snafu(display("Number of hidden layers ({n_hidden_layers}) not divisable by number of hidden groups ({n_hidden_groups})"))]
+    IncorrectNHiddenGroups {
+        n_hidden_groups: usize,
+        n_hidden_layers: usize,
+    },
+
+    #[snafu(display("Cannot apply transformer layer {n}"))]
+    TransformerLayer { source: BoxedError, n: usize },
+}
+
+/// ALBERT encoder (Lan et al., 2019).
+///
+/// See [ALBERT: A Lite BERT for Self-supervised Learning of Language Representations](https://arxiv.org/abs/1909.11942).
+pub struct AlbertEncoder {
+    embeddings: Box<dyn Embeddings>,
+    groups: Vec<Box<dyn EncoderLayer>>,
+    n_hidden_layers: usize,
+}
+
+impl Encoder for AlbertEncoder {
+    fn forward_t(
+        &self,
+        input: &Tensor,
+        attention_mask: &AttentionMask,
+        positions: Option<&Tensor>,
+        type_ids: Option<&Tensor>,
+        train: bool,
+    ) -> Result<EncoderOutput, BoxedError> {
+        let embeddings = self
+            .embeddings
+            .forward(input, train, positions, type_ids)
+            .context(EmbeddingsSnafu)?;
+
+        let mut layer_output = embeddings;
+        let mut layer_outputs = Vec::with_capacity(self.n_hidden_layers + 1);
+        layer_outputs.push(layer_output.clone());
+
+        let layers_per_group = self.n_hidden_layers / self.groups.len();
+
+        for (group_id, group) in self.groups.iter().enumerate() {
+            for layer_in_group in 0..layers_per_group {
+                layer_output = group
+                    .forward_t(&layer_output, attention_mask, positions, train)
+                    .context(TransformerLayerSnafu {
+                        n: group_id * layers_per_group + layer_in_group,
+                    })?;
+                layer_outputs.push(layer_output.clone());
+            }
+        }
+
+        Ok(EncoderOutput::new(layer_outputs))
+    }
+}
+
+impl FromHF for AlbertEncoder {
+    type Config = AlbertEncoderConfig;
+
+    type HFConfig = HFAlbertEncoderConfig;
+
+    type Model = AlbertEncoder;
+
+    fn rename_parameters() -> impl Fn(&str) -> String {
+        |name| {
+            let mut name = if name.starts_with("encoder.") {
+                name.replace("encoder.", "albert.")
+            } else if !name.starts_with("predictions") {
+                format!("albert.{name}")
+            } else {
+                name.to_string()
+            };
+
+            // Embeddings
+            name = name.replace("piece_embeddings", "word_embeddings");
+            name = name.replace("type_embeddings", "token_type_embeddings");
+            name = name.replace("embedding_layer_norm", "LayerNorm");
+            name = name.replace(
+                "embeddings.projection.",
+                "encoder.embedding_hidden_mapping_in.",
+            );
+
+            // Layers
+            static GROUP_RE: OnceLock<Regex> = OnceLock::new();
+            let layer_re =
+                GROUP_RE.get_or_init(|| Regex::new(r"group_(\d+)").expect("Invalid regex"));
+            name = layer_re
+                .replace(&name, "encoder.albert_layer_groups.$1")
+                .to_string();
+            static GROUP_LAYER_RE: OnceLock<Regex> = OnceLock::new();
+            let group_layer_re = GROUP_LAYER_RE
+                .get_or_init(|| Regex::new(r"group_layer_(\d+)").expect("Invalid regex"));
+            name = group_layer_re
+                .replace(&name, "albert_layers.$1")
+                .to_string();
+
+            // Attention layer.
+            name = name.replace("attention.output", "attention.dense");
+            name = name.replace("attn_residual_layer_norm", "attention.LayerNorm");
+
+            // Feed-forward layer.
+            name = name.replace("ffn.intermediate", "ffn");
+            name = name.replace("ffn.output", "ffn_output");
+            name = name.replace("ffn_residual_layer_norm", "full_layer_layer_norm");
+
+            name
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use candle_core::Device;
+    use ndarray::array;
+    use snafu::{report, FromString, ResultExt, Whatever};
+
+    use crate::architectures::{Encoder, LayerOutputs};
+    use crate::models::hf::FromHFHub;
+    use crate::util::tests::{assert_tensor_eq, sample_transformer_inputs, PseudoRandomReduction};
+
+    use super::AlbertEncoder;
+
+    #[test]
+    #[report]
+    fn albert_encoder_emits_correct_output() -> Result<(), Whatever> {
+        let encoder =
+            AlbertEncoder::from_hf_hub("explosion-testing/albert-test", None, Device::Cpu)
+                .with_whatever_context(|_| "Cannot load model")?;
+
+        let (input, mask) = sample_transformer_inputs()?;
+
+        let output = encoder
+            .forward_t(&input, &mask, None, None, false)
+            .map_err(|e| Whatever::with_source(e, "Cannot encode input".to_string()))?;
+
+        let last_output = output.layer_outputs().last().unwrap();
+
+        assert_tensor_eq::<f32>(
+            last_output
+                .pseudo_random_reduction()
+                .whatever_context("Cannot apply reduction using random vector")?,
+            array![
+                [0.4989, -0.3332, 3.2000, -3.6963, 0.0619, 0.1232, 2.3507, -2.1934],
+                [-3.3217, 2.9269, 3.4843, -0.7933, -3.8832, -0.7925, 1.8436, -0.9704],
+                [0.5875, 0.8119, 6.6794, 0.0263, -2.5903, 0.1582, 4.9209, 3.9640]
+            ],
+            1e-4,
+        );
+
+        Ok(())
+    }
+}

--- a/src/models/albert/layer.rs
+++ b/src/models/albert/layer.rs
@@ -1,0 +1,92 @@
+use candle_core::Tensor;
+use snafu::{ResultExt, Snafu};
+
+use crate::{
+    architectures::{BuildEncoderLayer, EncoderLayer},
+    error::BoxedError,
+    layers::{attention::AttentionMask, transformer::TransformerLayerConfig},
+};
+
+/// ALBERT layer group errors.
+#[derive(Debug, Snafu)]
+enum BuildAlbertLayerGroupError {
+    #[snafu(display("Cannot build ALBERT group layer {n}"))]
+    BuildTransformerLayer {
+        source: crate::error::BoxedError,
+        n: usize,
+    },
+}
+
+/// ALBERT layer group configuration
+///
+/// A group's layer can in turn consist of multiple layers (though this is
+/// rarely used in ALBERT models).
+#[derive(Debug)]
+pub struct AlbertLayerGroupConfig {
+    n_layers_per_group: usize,
+    transformer_layer: TransformerLayerConfig,
+}
+
+impl AlbertLayerGroupConfig {
+    /// Number of layers within a group layer.
+    pub fn n_layers_per_group(mut self, n_layers_per_group: usize) -> Self {
+        self.n_layers_per_group = n_layers_per_group;
+        self
+    }
+
+    /// Transformer layer configuration.
+    pub fn transformer_layer(mut self, transformer_layer: TransformerLayerConfig) -> Self {
+        self.transformer_layer = transformer_layer;
+        self
+    }
+}
+
+impl Default for AlbertLayerGroupConfig {
+    fn default() -> Self {
+        Self {
+            n_layers_per_group: 1,
+            transformer_layer: TransformerLayerConfig::default(),
+        }
+    }
+}
+
+impl BuildEncoderLayer for AlbertLayerGroupConfig {
+    fn build_encoder_layer(
+        &self,
+        vb: candle_nn::VarBuilder,
+    ) -> Result<Box<dyn crate::architectures::EncoderLayer>, crate::error::BoxedError> {
+        let layers = (0..self.n_layers_per_group)
+            .map({
+                |n| {
+                    self.transformer_layer
+                        .build_encoder_layer(vb.push_prefix(format!("group_layer_{n}")))
+                        .context(BuildTransformerLayerSnafu { n })
+                }
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(Box::new(AlbertLayerGroup { layers }))
+    }
+}
+
+pub struct AlbertLayerGroup {
+    layers: Vec<Box<dyn EncoderLayer>>,
+}
+
+impl EncoderLayer for AlbertLayerGroup {
+    fn forward_t(
+        &self,
+        input: &Tensor,
+        mask: &AttentionMask,
+        positions: Option<&Tensor>,
+        train: bool,
+    ) -> Result<Tensor, BoxedError> {
+        let mut layer_output = input.clone();
+
+        for layer in &self.layers {
+            layer_output = layer.forward_t(&layer_output, mask, positions, train)?;
+        }
+
+        Ok(layer_output)
+    }
+}

--- a/src/models/albert/mod.rs
+++ b/src/models/albert/mod.rs
@@ -1,0 +1,5 @@
+mod layer;
+pub use layer::AlbertLayerGroupConfig;
+
+mod encoder;
+pub use encoder::{AlbertEncoder, AlbertEncoderConfig};

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,3 +1,6 @@
+mod albert;
+pub use albert::{AlbertEncoder, AlbertEncoderConfig};
+
 mod bert;
 pub use bert::BertEncoder;
 


### PR DESCRIPTION
Also exposes `AlbertEncoderConfig`, `AlbertLayerGroup`, and `AlbertLayerGroupConfig`, since ALBERT does not use `TransformerEncoder` and `TransformerEncoderLayer`.