### PR TITLE
Remove `KeyValueCache::cache` hyperparameters

### DIFF
--- a/src/layers/embeddings/qk_rotary_embeddings.rs
+++ b/src/layers/embeddings/qk_rotary_embeddings.rs
@@ -400,8 +400,7 @@ mod tests {
                 1e-4,
             );
 
-            let mut cache = LayerKeyValueCache::cache(1, 8, 1, DType::F32, &Device::Cpu)
-                .whatever_context("Cannot create cache")?;
+            let mut cache = LayerKeyValueCache::empty();
             cache
                 .update(
                     &Tensor::zeros((1, 1, 16, 8), DType::F32, &Device::Cpu).unwrap(),

--- a/src/models/gpt_neox/causal_lm.rs
+++ b/src/models/gpt_neox/causal_lm.rs
@@ -70,7 +70,7 @@ mod tests {
         let (input, mask) = sample_transformer_inputs()?;
 
         let output = causal_lm
-            .forward_t(&input, &mask, &mut KeyValueCache::no_cache(5), None, false)
+            .forward_t(&input, &mask, &mut KeyValueCache::no_cache(), None, false)
             .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))?;
 
         let logits = output.logits();

--- a/src/models/gpt_neox/decoder.rs
+++ b/src/models/gpt_neox/decoder.rs
@@ -157,7 +157,7 @@ impl FromHF for GPTNeoXDecoder {
 
 #[cfg(test)]
 mod tests {
-    use candle_core::{DType, Device};
+    use candle_core::Device;
     use ndarray::array;
     use snafu::{report, FromString, ResultExt, Whatever};
 
@@ -181,7 +181,7 @@ mod tests {
         let (input, mask) = sample_transformer_inputs()?;
 
         let output = decoder
-            .forward_t(&input, &mask, &mut KeyValueCache::no_cache(5), None, false)
+            .forward_t(&input, &mask, &mut KeyValueCache::no_cache(), None, false)
             .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))?;
 
         let last_output = output.layer_outputs().last().unwrap();
@@ -213,9 +213,7 @@ mod tests {
 
         let (input, mask) = sample_transformer_inputs()?;
 
-        let mut cache =
-            KeyValueCache::cache(input.shape().dims()[0], 32, 4, 5, DType::F32, &Device::Cpu)
-                .whatever_context("Cannot create cache")?;
+        let mut cache = KeyValueCache::cache();
         let attention_mask = AttentionMask::new(
             mask.bool_mask()
                 .narrow(1, 0, 7)

--- a/src/models/llama/causal_lm.rs
+++ b/src/models/llama/causal_lm.rs
@@ -70,7 +70,7 @@ mod tests {
         let (input, mask) = sample_transformer_inputs()?;
 
         let output = causal_lm
-            .forward_t(&input, &mask, &mut KeyValueCache::no_cache(5), None, false)
+            .forward_t(&input, &mask, &mut KeyValueCache::no_cache(), None, false)
             .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))?;
 
         assert_tensor_eq::<f32>(

--- a/src/models/llama/decoder.rs
+++ b/src/models/llama/decoder.rs
@@ -143,7 +143,7 @@ impl FromHF for LlamaDecoder {
 
 #[cfg(test)]
 mod tests {
-    use candle_core::{DType, Device};
+    use candle_core::Device;
     use ndarray::array;
     use snafu::{report, FromString, ResultExt, Whatever};
 
@@ -164,7 +164,7 @@ mod tests {
         let (input, mask) = sample_transformer_inputs()?;
 
         let output = decoder
-            .forward_t(&input, &mask, &mut KeyValueCache::no_cache(5), None, false)
+            .forward_t(&input, &mask, &mut KeyValueCache::no_cache(), None, false)
             .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))?;
 
         let last_output = output.layer_outputs().last().unwrap();
@@ -193,9 +193,7 @@ mod tests {
 
         let (input, mask) = sample_transformer_inputs()?;
 
-        let mut cache =
-            KeyValueCache::cache(input.shape().dims()[0], 64, 1, 5, DType::F32, &Device::Cpu)
-                .whatever_context("Cannot create cache")?;
+        let mut cache = KeyValueCache::cache();
         let attention_mask = AttentionMask::new(
             mask.bool_mask()
                 .narrow(1, 0, 7)


### PR DESCRIPTION
`KeyValueCache::cache` required specifying a number of hyperparameters, which puts an unnecessary burden on downstream users. This change removes the arguments. Instead we rely on the first cache update to the key and value. We also store the layers in a `HashMap` rather than `Vec` to remove the need to specify the number of layers ahead of time.

Eventually, we want to preallocate the cache based on the maximum generation length, but we are not there yet. So keep it simple for now.