### PR TITLE
Add support for testing models on CPU, CUDA, Metal, and Accelerate

### DIFF
--- a/oxidized-transformers/Cargo.toml
+++ b/oxidized-transformers/Cargo.toml
@@ -22,3 +22,9 @@ rstest = { workspace = true }
 ndarray = { workspace = true, features = ["approx-0_5"] }
 rand_pcg = { workspace = true }
 rand_core = { workspace = true }
+
+[features]
+accelerate = ["candle-core/accelerate", "candle-nn/accelerate"]
+cuda = ["candle-core/cuda", "candle-nn/cuda"]
+cudnn = ["candle-core/cudnn"]
+metal = ["candle-core/metal", "candle-nn/metal"]

--- a/oxidized-transformers/src/layers/embeddings/qk_rotary_embeddings.rs
+++ b/oxidized-transformers/src/layers/embeddings/qk_rotary_embeddings.rs
@@ -186,8 +186,8 @@ impl QueryKeyRotaryEmbeddings {
 
                 Some(
                     Tensor::arange(
-                        cache_len as i64,
-                        cache_len as i64 + seq_len as i64,
+                        cache_len as u32,
+                        cache_len as u32 + seq_len as u32,
                         query.device(),
                     )
                     .and_then(|xs| xs.repeat((batch_size, 1)))
@@ -315,6 +315,8 @@ mod tests {
             let positions = Tensor::arange_step(4i64, 0, -1, &vb.device())
                 .unwrap()
                 .reshape((1, 4))
+                .unwrap()
+                .to_dtype(DType::U32)
                 .unwrap();
             let (query_rot, key_rot) = rotary
                 .forward(

--- a/oxidized-transformers/src/layers/embeddings/rotary_embeddings.rs
+++ b/oxidized-transformers/src/layers/embeddings/rotary_embeddings.rs
@@ -216,7 +216,7 @@ impl RotaryEmbeddings {
                 let positions_flat = positions.flatten_all().context(SliceCacheSnafu)?;
                 let max_len = positions_flat
                     .max(0)
-                    .and_then(|xs| xs.to_scalar::<i64>())
+                    .and_then(|xs| xs.to_scalar::<u32>())
                     .context(SliceCacheSnafu)? as usize
                     + 1;
 

--- a/oxidized-transformers/src/layers/transformer/embeddings.rs
+++ b/oxidized-transformers/src/layers/transformer/embeddings.rs
@@ -254,7 +254,7 @@ impl TransformerEmbeddings {
     /// Get position identifiers _[0..seq_len)_.
     fn get_positions(x: &Tensor) -> Result<Tensor, TransformerEmbeddingsError> {
         let (batch_size, seq_len) = x.shape().dims2().context(PositionEmbeddingsSnafu)?;
-        Tensor::arange(0, seq_len as i64, x.device())
+        Tensor::arange(0, seq_len as u32, x.device())
             .and_then(|xs| xs.reshape((1, seq_len)))
             .and_then(|xs| xs.repeat(&[batch_size, 1]))
             .context(PositionEmbeddingsSnafu)

--- a/oxidized-transformers/src/models/hf/from_hf.rs
+++ b/oxidized-transformers/src/models/hf/from_hf.rs
@@ -41,14 +41,15 @@ pub trait FromHF {
     fn from_hf(
         hf_config: HFConfigWithDType<Self::HFConfig>,
         backend: Box<dyn SimpleBackend>,
-        device: Device,
+        device: &Device,
     ) -> Result<Self::Model, FromHFError> {
         // Ideally we would not clone here, but TryFrom<&...> adds a lot of
         // pesky lifetime annotations everywhere.
         let config =
             Self::Config::try_from(hf_config.config().clone()).context(ConvertConfigSnafu)?;
         let rename_backend = RenamingBackend::new(backend, Self::rename_parameters());
-        let vb = VarBuilder::from_backend(Box::new(rename_backend), hf_config.dtype(), device);
+        let vb =
+            VarBuilder::from_backend(Box::new(rename_backend), hf_config.dtype(), device.clone());
         config.build(vb).context(BuildModelSnafu)
     }
 

--- a/oxidized-transformers/src/models/hf/hf_hub.rs
+++ b/oxidized-transformers/src/models/hf/hf_hub.rs
@@ -56,7 +56,7 @@ where
     fn from_hf_hub(
         name: &str,
         revision: Option<&str>,
-        device: Device,
+        device: &Device,
     ) -> Result<Self::Model, FromHfHubError>;
 }
 
@@ -71,7 +71,7 @@ where
     fn from_hf_hub(
         name: &str,
         revision: Option<&str>,
-        device: Device,
+        device: &Device,
     ) -> Result<Self::Model, FromHfHubError> {
         let repo = HfHubRepo::new(name, revision).context(HFHubRepoSnafu)?;
         let config_file = repo.file("config.json").context(HFHubRepoSnafu)?;

--- a/oxidized-transformers/src/models/mod.rs
+++ b/oxidized-transformers/src/models/mod.rs
@@ -13,3 +13,5 @@ mod llama;
 pub use llama::{LlamaCausalLM, LlamaDecoder};
 
 pub mod transformer;
+
+pub mod util;

--- a/oxidized-transformers/src/models/transformer/decoder.rs
+++ b/oxidized-transformers/src/models/transformer/decoder.rs
@@ -141,6 +141,8 @@ impl Decoder for TransformerDecoder {
 
         let mut layer_output = embeddings;
         let mut layer_outputs = Vec::with_capacity(self.layers.len() + 1);
+        layer_outputs.push(layer_output.clone());
+
         for (layer_idx, layer) in self.layers.iter().enumerate() {
             let next_layer_output = layer
                 .forward_t(

--- a/oxidized-transformers/src/models/util.rs
+++ b/oxidized-transformers/src/models/util.rs
@@ -1,0 +1,255 @@
+#[cfg(test)]
+pub(crate) mod tests {
+    use candle_core::{Device, Tensor};
+    use snafu::{ensure_whatever, FromString, ResultExt, Whatever};
+
+    use crate::architectures::{CausalLM, Decoder, Encoder, LayerOutputs};
+    use crate::kv_cache::KeyValueCache;
+    use crate::layers::attention::AttentionMask;
+    use crate::models::hf::FromHFHub;
+    use crate::util::device::tests::test_devices;
+    use crate::util::tests::{assert_tensor_eq, IntoArrayD, PseudoRandomReduction};
+
+    /// Sample transformer inputs used for most tests.
+    pub fn sample_transformer_inputs(device: &Device) -> Result<(Tensor, AttentionMask), Whatever> {
+        let input = Tensor::arange(0u32, 24, device)
+            .and_then(|t| t.reshape((3, 8)))
+            .whatever_context("Cannot create input tensor")?;
+
+        let mask = Tensor::from_slice(
+            &[
+                1u8, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 1, 0, 1, 1, 0, 0, 1, 1, 0,
+            ],
+            (3, 8),
+            device,
+        )
+        .whatever_context("Cannot create attention mask tensor")?;
+
+        Ok((
+            input,
+            AttentionMask::new(mask).whatever_context("Cannot create attention mask")?,
+        ))
+    }
+
+    /// Check causal language model against test vectors.
+    ///
+    /// * `model_name` - The name of the model to test.
+    /// * `model_revision` - The revision of the model to test.
+    /// * `test_tensor` - The expected output tensor.
+    ///   Shape: `(batch_size, sequence_length)`.
+    pub fn check_causal_lm<C, M>(
+        model_name: &str,
+        model_revision: Option<&str>,
+        test_tensor: impl IntoArrayD<f32>,
+    ) -> Result<(), Whatever>
+    where
+        C: FromHFHub<Model = M>,
+        M: CausalLM<Cache = KeyValueCache>,
+    {
+        let test_tensor = test_tensor
+            .into_arrayd()
+            .whatever_context("Cannot convert tensor")?;
+
+        for device in test_devices() {
+            let causal_lm = C::from_hf_hub(model_name, model_revision, &device)
+                .whatever_context("Cannot load causal language model")?;
+
+            let (input, mask) = sample_transformer_inputs(&device)?;
+
+            let output = causal_lm
+                .forward_t(&input, &mask, &mut KeyValueCache::no_cache(), None, false)
+                .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))?;
+
+            assert_tensor_eq::<f32>(
+                output
+                    .logits()
+                    .pseudo_random_reduction()
+                    .whatever_context("Cannot apply reduction using random vector")?,
+                test_tensor.view(),
+                1e-4,
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Check decoder against test vectors.
+    ///
+    /// * `model_name` - The name of the model to test.
+    /// * `model_revision` - The revision of the model to test.
+    /// * `test_tensor` - The expected output tensor.
+    ///   Shape: `(batch_size, sequence_length)`.
+    pub fn check_decoder<D, M>(
+        model_name: &str,
+        model_revision: Option<&str>,
+        test_tensor: impl IntoArrayD<f32>,
+    ) -> Result<(), Whatever>
+    where
+        D: FromHFHub<Model = M>,
+        M: Decoder<Cache = KeyValueCache>,
+    {
+        let test_tensor = test_tensor
+            .into_arrayd()
+            .whatever_context("Cannot convert tensor")?;
+
+        for device in test_devices() {
+            let decoder = D::from_hf_hub(model_name, model_revision, &device)
+                .whatever_context("Cannot load decoder")?;
+
+            let (input, mask) = sample_transformer_inputs(&device)?;
+
+            let output = decoder
+                .forward_t(&input, &mask, &mut KeyValueCache::no_cache(), None, false)
+                .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))?;
+
+            ensure_whatever!(
+                !output.layer_outputs().is_empty(),
+                "Model did not have any outputs"
+            );
+            let last_output = output.layer_outputs().last().unwrap();
+
+            assert_tensor_eq::<f32>(
+                last_output
+                    .pseudo_random_reduction()
+                    .whatever_context("Cannot apply reduction using random vector")?,
+                test_tensor.view(),
+                1e-4,
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Check decoder with cache against test vectors.
+    ///
+    /// * `model_name` - The name of the model to test.
+    /// * `model_revision` - The revision of the model to test.
+    /// * `test_tensor` - The expected output tensor.
+    ///   Shape: `(batch_size, sequence_length)`.
+    pub fn check_decoder_with_cache<D, M>(
+        model_name: &str,
+        model_revision: Option<&str>,
+        test_tensor: impl IntoArrayD<f32>,
+    ) -> Result<(), Whatever>
+    where
+        D: FromHFHub<Model = M>,
+        M: Decoder<Cache = KeyValueCache>,
+    {
+        let test_tensor = test_tensor
+            .into_arrayd()
+            .whatever_context("Cannot convert tensor")?;
+
+        for device in test_devices() {
+            let decoder = D::from_hf_hub(model_name, model_revision, &device)
+                .whatever_context("Cannot load decoder")?;
+
+            let (input, mask) = sample_transformer_inputs(&device)?;
+
+            let mut cache = KeyValueCache::cache();
+            let attention_mask = AttentionMask::new(
+                mask.bool_mask()
+                    .narrow(1, 0, 7)
+                    .whatever_context("Cannot slice attention mask")?,
+            )
+            .whatever_context("Cannot build attention mask")?;
+
+            decoder
+                .forward_t(
+                    &input
+                        .narrow(1, 0, 7)
+                        .whatever_context("Cannot slice input")?,
+                    &attention_mask,
+                    &mut cache,
+                    None,
+                    false,
+                )
+                .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))?;
+
+            let attention_mask = attention_mask
+                .extend(
+                    &AttentionMask::new(
+                        mask.bool_mask()
+                            .narrow(1, 7, 1)
+                            .whatever_context("Cannot slice attention mask")?,
+                    )
+                    .whatever_context("Cannot build attention mask")?,
+                )
+                .whatever_context("Cannot extend attention mask")?;
+
+            let output = decoder
+                .forward_t(
+                    &input
+                        .narrow(1, 7, 1)
+                        .whatever_context("Cannot slice input")?,
+                    &attention_mask,
+                    &mut cache,
+                    None,
+                    false,
+                )
+                .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))?;
+
+            ensure_whatever!(
+                !output.layer_outputs().is_empty(),
+                "Model did not have any outputs"
+            );
+            let last_output = output.layer_outputs().last().unwrap();
+
+            assert_tensor_eq::<f32>(
+                last_output
+                    .pseudo_random_reduction()
+                    .whatever_context("Cannot apply reduction using random vector")?,
+                test_tensor.view(),
+                1e-4,
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Check encoder against test vectors.
+    ///
+    /// * `model_name` - The name of the model to test.
+    /// * `model_revision` - The revision of the model to test.
+    /// * `test_tensor` - The expected output tensor.
+    ///   Shape: `(batch_size, sequence_length)`.
+    pub fn check_encoder<E, M>(
+        model_name: &str,
+        model_revision: Option<&str>,
+        test_tensor: impl IntoArrayD<f32>,
+    ) -> Result<(), Whatever>
+    where
+        E: FromHFHub<Model = M>,
+        M: Encoder,
+    {
+        let test_tensor = test_tensor
+            .into_arrayd()
+            .whatever_context("Cannot convert tensor")?;
+
+        for device in test_devices() {
+            let encoder = E::from_hf_hub(model_name, model_revision, &device)
+                .whatever_context("Cannot load encoder")?;
+
+            let (input, mask) = sample_transformer_inputs(&device)?;
+
+            let output = encoder
+                .forward_t(&input, &mask, None, None, false)
+                .map_err(|e| Whatever::with_source(e, "Cannot encode input".to_string()))?;
+
+            ensure_whatever!(
+                !output.layer_outputs().is_empty(),
+                "Model did not have any outputs"
+            );
+            let last_output = output.layer_outputs().last().unwrap();
+
+            assert_tensor_eq::<f32>(
+                last_output
+                    .pseudo_random_reduction()
+                    .whatever_context("Cannot apply reduction using random vector")?,
+                test_tensor.view(),
+                1e-4,
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/oxidized-transformers/src/util/device.rs
+++ b/oxidized-transformers/src/util/device.rs
@@ -1,0 +1,19 @@
+#[cfg(test)]
+pub(crate) mod tests {
+    use candle_core::Device;
+
+    /// Get devices to test on.
+    pub fn test_devices() -> Vec<Device> {
+        let mut devices = vec![Device::Cpu];
+
+        if let Ok(device) = Device::new_cuda(0) {
+            devices.push(device);
+        }
+
+        if let Ok(device) = Device::new_metal(0) {
+            devices.push(device);
+        }
+
+        devices
+    }
+}


### PR DESCRIPTION
This change combines a several changes to enable tests on non-CPU devices:

* Factor out the vector tests to reusable check functions.
* The check functions try all available device types. Ideally this would be done using parametrized tests, but this is not supported by rstest due to Rust limitations.
* A bunch of changes small changes to fix Metal support (mostly switching to supported data types).
* Add `accelerate`, `cuda`, `cudnn`, and `metal` features.

**Note:** Metal tests currently fail due to one remaining issue, I am preparing an upstream PR to fix this.