### PR TITLE
Fix float16 support for causal language models

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ repository = "https://github.com/oxidized-transformers/oxidized-transformers"
 approx = "0.5"
 candle-core = "0.4"
 candle-nn = "0.4"
+half = "2.4"
 hf-hub = "0.3"
 ndarray = { version = "0.15.4", features = ["approx-0_5"] }
 rand_pcg = "0.3"

--- a/oxidized-transformers/Cargo.toml
+++ b/oxidized-transformers/Cargo.toml
@@ -11,6 +11,7 @@ homepage.workspace = true
 [dependencies]
 candle-core = { workspace = true }
 candle-nn = { workspace = true }
+half = { workspace = true }
 hf-hub = { workspace = true }
 regex = { workspace = true }
 snafu = { workspace = true }

--- a/oxidized-transformers/src/layers/attention/alibi.rs
+++ b/oxidized-transformers/src/layers/attention/alibi.rs
@@ -196,19 +196,19 @@ mod tests {
             .n_attention_heads(8)
             .build()
             .unwrap();
-        assert_tensor_eq(
+        assert_tensor_eq!(
             &pow2_biases.slopes,
             array![0.5f32, 0.25, 0.125, 0.0625, 0.03125, 0.015625, 0.0078125, 0.00390625,]
                 .into_shape((1, 8, 1, 1))
                 .unwrap(),
-            1e-4,
+            epsilon = 1e-4,
         );
 
         let non_pow2_biases = AttentionLinearBiasesConfig::default()
             .n_attention_heads(12)
             .build()
             .unwrap();
-        assert_tensor_eq(
+        assert_tensor_eq!(
             &non_pow2_biases.slopes,
             array![
                 0.5f32,
@@ -226,7 +226,7 @@ mod tests {
             ]
             .into_shape((1, 12, 1, 1))
             .unwrap(),
-            1e-4,
+            epsilon = 1e-4,
         );
     }
 
@@ -239,7 +239,7 @@ mod tests {
             .is_causal(true)
             .build()
             .unwrap();
-        assert_tensor_eq(
+        assert_tensor_eq!(
             &causal
                 .forward(&Tensor::zeros((1, 4, 1, 3), DType::F32, &device).unwrap())
                 .unwrap(),
@@ -259,7 +259,7 @@ mod tests {
             ]
             .into_shape((1, 4, 1, 3))
             .unwrap(),
-            1e-4,
+            epsilon = 1e-4,
         );
 
         let inverted = AttentionLinearBiasesConfig::default()
@@ -268,7 +268,7 @@ mod tests {
             .is_inverted(true)
             .build()
             .unwrap();
-        assert_tensor_eq(
+        assert_tensor_eq!(
             &inverted
                 .forward(&Tensor::zeros((1, 4, 1, 3), DType::F32, &device).unwrap())
                 .unwrap(),
@@ -278,7 +278,7 @@ mod tests {
             ]
             .into_shape((1, 4, 1, 3))
             .unwrap(),
-            1e-4,
+            epsilon = 1e-4,
         );
     }
 
@@ -290,7 +290,7 @@ mod tests {
             .n_attention_heads(4)
             .build()
             .unwrap();
-        assert_tensor_eq(
+        assert_tensor_eq!(
             &non_causal
                 .forward(&Tensor::zeros((1, 4, 3, 3), DType::F32, &device).unwrap())
                 .unwrap(),
@@ -334,7 +334,7 @@ mod tests {
             ]
             .into_shape((1, 4, 3, 3))
             .unwrap(),
-            1e-4,
+            epsilon = 1e-4,
         );
 
         let inverted = AttentionLinearBiasesConfig::default()
@@ -342,7 +342,7 @@ mod tests {
             .is_inverted(true)
             .build()
             .unwrap();
-        assert_tensor_eq(
+        assert_tensor_eq!(
             &inverted
                 .forward(&Tensor::zeros((1, 4, 3, 3), DType::F32, &device).unwrap())
                 .unwrap(),
@@ -355,7 +355,7 @@ mod tests {
             ]
             .into_shape((1, 4, 3, 3))
             .unwrap(),
-            1e-4,
+            epsilon = 1e-4,
         );
     }
 }

--- a/oxidized-transformers/src/layers/embeddings/qk_rotary_embeddings.rs
+++ b/oxidized-transformers/src/layers/embeddings/qk_rotary_embeddings.rs
@@ -268,7 +268,7 @@ mod tests {
                 .forward(&query, &key, &mut LayerKeyValueCache::no_cache(), None)
                 .unwrap();
 
-            assert_tensor_eq(
+            assert_tensor_eq!(
                 &query_rot,
                 array![
                     [0.0000f32, 1.0000, 2.0000, 3.0000],
@@ -278,9 +278,9 @@ mod tests {
                 ]
                 .into_shape((1, 1, 4, 4))
                 .unwrap(),
-                1e-4,
+                epsilon = 1e-4,
             );
-            assert_tensor_eq(
+            assert_tensor_eq!(
                 &key_rot,
                 array![
                     [16.0000f32, 17.0000, 18.0000, 19.0000],
@@ -290,7 +290,7 @@ mod tests {
                 ]
                 .into_shape((1, 1, 4, 4))
                 .unwrap(),
-                1e-4,
+                epsilon = 1e-4,
             );
         }
     }
@@ -327,7 +327,7 @@ mod tests {
                 )
                 .unwrap();
 
-            assert_tensor_eq(
+            assert_tensor_eq!(
                 &query_rot,
                 array![
                     [1.5136f32, 0.8792, -1.3073, 3.0376],
@@ -337,9 +337,9 @@ mod tests {
                 ]
                 .into_shape((1, 1, 4, 4))
                 .unwrap(),
-                1e-4,
+                epsilon = 1e-4,
             );
-            assert_tensor_eq(
+            assert_tensor_eq!(
                 &key_rot,
                 array![
                     [3.1641f32, 16.2266, -23.8744, 19.6646],
@@ -349,7 +349,7 @@ mod tests {
                 ]
                 .into_shape((1, 1, 4, 4))
                 .unwrap(),
-                1e-4,
+                epsilon = 1e-4,
             );
         }
     }
@@ -376,7 +376,7 @@ mod tests {
                 .forward(&query, &key, &mut LayerKeyValueCache::no_cache(), None)
                 .whatever_context("Cannot apply rotary embeddings to input with cache")?;
 
-            assert_tensor_eq(
+            assert_tensor_eq!(
                 &query_rot,
                 array![
                     [0.0000f32, 1.0000, 2.0000, 3.0000, 4.0000, 5.0000, 6.0000, 7.0000],
@@ -386,10 +386,10 @@ mod tests {
                 ]
                 .into_shape((1, 1, 4, 8))
                 .unwrap(),
-                1e-4,
+                epsilon = 1e-4,
             );
 
-            assert_tensor_eq(
+            assert_tensor_eq!(
                 &key_rot,
                 array![
                     [32.0000f32, 33.0000, 34.0000, 35.0000, 36.0000, 37.0000, 38.0000, 39.0000],
@@ -399,7 +399,7 @@ mod tests {
                 ]
                 .into_shape((1, 1, 4, 8))
                 .unwrap(),
-                1e-4,
+                epsilon = 1e-4,
             );
 
             let mut cache = LayerKeyValueCache::empty();
@@ -414,7 +414,7 @@ mod tests {
                 .forward(&query, &key, &cache, None)
                 .whatever_context("Cannot apply rotary embeddings to input with cache")?;
 
-            assert_tensor_eq(
+            assert_tensor_eq!(
                 &query_rot,
                 array![
                     [0.5758f32, 0.5093, -1.9153, 3.1210, 4.0000, 5.0000, 6.0000, 7.0000],
@@ -424,10 +424,10 @@ mod tests {
                 ]
                 .into_shape((1, 1, 4, 8))
                 .unwrap(),
-                1e-4,
+                epsilon = 1e-4,
             );
 
-            assert_tensor_eq(
+            assert_tensor_eq!(
                 &key_rot,
                 array![
                     [
@@ -446,7 +446,7 @@ mod tests {
                 ]
                 .into_shape((1, 1, 4, 8))
                 .unwrap(),
-                1e-4,
+                epsilon = 1e-4,
             );
         }
 

--- a/oxidized-transformers/src/models/gpt_neox/causal_lm.rs
+++ b/oxidized-transformers/src/models/gpt_neox/causal_lm.rs
@@ -55,15 +55,33 @@ mod tests {
 
     #[test]
     #[report]
-    fn gptneox_causal_lm_emits_correct_output() -> Result<(), Whatever> {
-        check_causal_lm::<GPTNeoXCausalLM, _>(
+    fn gpt_neox_causal_lm_emits_correct_output() -> Result<(), Whatever> {
+        check_causal_lm!(
+            GPTNeoXCausalLM,
             "trl-internal-testing/tiny-random-GPTNeoXForCausalLM-safetensors-sharded",
             None,
             array![
-                [-1.4418, -3.5698, -1.8183, 2.8572, 0.8718, 1.2548, 1.4918, 1.5812],
-                [0.8485, 3.3328, 2.5758, 3.2619, 2.9896, 2.0168, -0.2824, -1.9384],
-                [-0.6713, -0.7587, -3.1774, -0.7306, 1.5888, 3.4785, 3.6013, 1.1660]
+                [-1.4418, 0.0000, -1.8183, 0.0000, 0.0000, 1.2548, 0.0000, 0.0000],
+                [0.8485, 0.0000, 0.0000, 3.2619, 0.0000, 2.0168, -0.2824, -1.9384],
+                [0.0000, -0.7587, -3.1774, 0.0000, 0.0000, 3.4785, 3.6013, 0.0000]
             ],
+            epsilon = 1e-4,
+        )
+    }
+
+    #[test]
+    #[report]
+    fn gpt_neox_causal_lm_emits_correct_output_float16() -> Result<(), Whatever> {
+        check_causal_lm!(
+            GPTNeoXCausalLM,
+            "explosion-testing/gpt-neox-float16",
+            None,
+            array![
+                [-1.4418, 0.0000, -1.8183, 0.0000, 0.0000, 1.2548, 0.0000, 0.0000],
+                [0.8485, 0.0000, 0.0000, 3.2619, 0.0000, 2.0168, -0.2824, -1.9384],
+                [0.0000, -0.7587, -3.1774, 0.0000, 0.0000, 3.4785, 3.6013, 0.0000]
+            ],
+            epsilon = 1e-1
         )
     }
 }

--- a/oxidized-transformers/src/models/llama/causal_lm.rs
+++ b/oxidized-transformers/src/models/llama/causal_lm.rs
@@ -59,14 +59,32 @@ mod tests {
     #[test]
     #[report]
     fn llama_causal_lm_emits_correct_output() -> Result<(), Whatever> {
-        check_causal_lm::<LlamaCausalLM, _>(
+        check_causal_lm!(
+            LlamaCausalLM,
             "explosion-testing/llama2-kv-sharing",
             None,
             array![
-                [0.0000, -0.7422, 3.9272, 2.4643, 1.2032, -0.2746, 0.0612, 2.6404],
-                [-1.6657, -1.5350, -0.9877, 0.1828, 0.2311, 0.7174, 0.4477, -0.4943],
-                [-1.4341, -2.5877, -1.4347, -1.1339, -1.8117, -0.2561, -0.6859, -2.5824]
+                [0.0000, 0.0000, 3.9272, 0.0000, 0.0000, -0.2746, 0.0000, 0.0000],
+                [-1.6657, 0.0000, 0.0000, 0.1828, 0.0000, 0.7174, 0.4477, -0.4943],
+                [0.0000, -2.5876, -1.4347, 0.0000, 0.0000, -0.2561, -0.6859, 0.0000]
             ],
+            epsilon = 1e-4,
+        )
+    }
+
+    #[test]
+    #[report]
+    fn llama_causal_lm_emits_correct_output_float16() -> Result<(), Whatever> {
+        check_causal_lm!(
+            LlamaCausalLM,
+            "explosion-testing/llama2-kv-sharing-float16",
+            None,
+            array![
+                [0.0000, 0.0000, 3.9272, 0.0000, 0.0000, -0.2746, 0.0000, 0.0000],
+                [-1.6657, 0.0000, 0.0000, 0.1828, 0.0000, 0.7174, 0.4477, -0.4943],
+                [0.0000, -2.5876, -1.4347, 0.0000, 0.0000, -0.2561, -0.6859, 0.0000]
+            ],
+            epsilon = 1e-1
         )
     }
 }

--- a/oxidized-transformers/src/util/tensor_ext.rs
+++ b/oxidized-transformers/src/util/tensor_ext.rs
@@ -1,0 +1,27 @@
+/// Tensor extension traits.
+use candle_core::{DType, Tensor};
+use half::{bf16, f16};
+
+/// Get a tensor with the data types minimum value.
+pub trait MinLike: Sized {
+    /// Get a new tensor with the data type's minimum value.
+    ///
+    /// The tensor has the same shape as `self`.
+    fn min_like(&self) -> Result<Self, candle_core::Error>;
+}
+
+impl MinLike for Tensor {
+    fn min_like(&self) -> Result<Self, candle_core::Error> {
+        match self.dtype() {
+            DType::BF16 => Tensor::try_from(bf16::MIN),
+            DType::F16 => Tensor::try_from(f16::MIN),
+            DType::F32 => Tensor::try_from(f32::MIN),
+            DType::F64 => Tensor::try_from(f64::MIN),
+            DType::U8 => Tensor::try_from(u8::MIN),
+            DType::U32 => Tensor::try_from(u32::MIN),
+            DType::I64 => Tensor::try_from(i64::MIN),
+        }
+        .and_then(|scalar| scalar.broadcast_as(self.shape()))
+        .and_then(|tensor| tensor.to_device(self.device()))
+    }
+}


### PR DESCRIPTION
Fix several dtype issues:

- When applying the logits mask, ensure that it is the right type.
- Use the minimum value for the dtype when applying the logits mask to avoid NaNs (as a result of -Infs).
- Convert rotary embeddings to the model's dtype.

The change also adds some tests for the float16 support. The tests are restricted to causal language models for now, since we primarily want to check that the models don't fail due to incorrect data types.

Furthermore, we now mask the logits before applying the test, to avoid large variances compared to HF test vectors for masked positions.

While at it, `assert_tensor_eq` and `check_causal_lm` are converted to macros, so that we can also use relative tolerances in the future. This is currently not used, but I experimented with relative tolerances while preparing this change and it would be a bit of a shame to let it whither.