### PR TITLE
Add `Nonzero` trait and implement for `Tensor`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ members = [
     "oxidized-transformers",
     "oxidized-transformers-pyo3"
 ]
+exclude = [
+    "oxidized-cuda-kernels",
+]
 resolver = "2"
 
 [workspace.package]
@@ -17,9 +20,11 @@ repository = "https://github.com/oxidized-transformers/oxidized-transformers"
 approx = "0.5"
 candle-core = "0.4"
 candle-nn = "0.4"
+cudarc = { version = "0.10.0", features = ["f16"] }
 half = "2.4"
 hf-hub = "0.3"
 ndarray = { version = "0.15.4", features = ["approx-0_5"] }
+oxidized-cuda-kernels = { path = "./oxidized-cuda-kernels" }
 rand_pcg = "0.3"
 rand_core = "0.6"
 regex = "1.10"

--- a/oxidized-cuda-kernels/Cargo.toml
+++ b/oxidized-cuda-kernels/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "oxidized-cuda-kernels"
+description = "Additional CUDA kernels for Oxidized Transformers"
+version = "0.1.1"
+edition = "2021"
+license = "MIT or Apache-2.0"
+repository = "https://github.com/oxidized-transformers/oxidized-transformers"
+
+[dependencies]
+candle-core = { version = "0.4", features = ["cuda"] }
+cudarc = { version = "0.10", features = ["f16"] }
+half = "2.4"
+
+[build-dependencies]
+bindgen_cuda = "0.1.1"
+snafu = "0.8"

--- a/oxidized-cuda-kernels/build.rs
+++ b/oxidized-cuda-kernels/build.rs
@@ -1,0 +1,29 @@
+use std::path::PathBuf;
+
+use snafu::{report, ResultExt, Whatever};
+
+static KERNELS: &[&str] = &["src/nonzero.cu"];
+
+#[report]
+fn main() -> Result<(), Whatever> {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=src/step_output_iterator.cuh");
+    for kernel in KERNELS {
+        println!("cargo:rerun-if-changed={kernel}");
+    }
+
+    let builder = bindgen_cuda::Builder::default()
+        .kernel_paths(KERNELS.iter().collect())
+        .arg("-std=c++17")
+        .arg("-O3")
+        .arg("--use_fast_math")
+        .arg("--verbose");
+    let out_dir = PathBuf::from(std::env::var("OUT_DIR").whatever_context("OUT_DIR not set")?);
+    builder.build_lib(out_dir.join("liboxidized_cuda_kernels.a"));
+    println!("cargo:rustc-link-search={}", out_dir.display());
+    println!("cargo:rustc-link-lib=oxidized_cuda_kernels");
+    println!("cargo:rustc-link-lib=dylib=cudart");
+    println!("cargo:rustc-link-lib=dylib=stdc++");
+
+    Ok(())
+}

--- a/oxidized-cuda-kernels/src/ffi.rs
+++ b/oxidized-cuda-kernels/src/ffi.rs
@@ -1,0 +1,26 @@
+use cudarc::driver::sys::{CUdeviceptr, CUstream};
+use half::{bf16, f16};
+
+macro_rules! nonzero {
+    ($name:ident, $type:ty) => {
+        extern "C" {
+            pub(crate) fn $name(
+                num_elems: usize,
+                num_dims: usize,
+                info: *const usize,
+                input: *const $type,
+                out: *mut CUdeviceptr,
+                num_nonzeros: *mut usize,
+                stream: CUstream,
+            );
+        }
+    };
+}
+
+nonzero!(nonzero_bf16, bf16);
+nonzero!(nonzero_f16, f16);
+nonzero!(nonzero_f32, f32);
+nonzero!(nonzero_f64, f64);
+nonzero!(nonzero_u8, u8);
+nonzero!(nonzero_u32, u32);
+nonzero!(nonzero_i64, i64);

--- a/oxidized-cuda-kernels/src/lib.rs
+++ b/oxidized-cuda-kernels/src/lib.rs
@@ -1,0 +1,5 @@
+/// Additional CUDA kernels for Oxidized Transformers.
+pub(crate) mod ffi;
+
+mod nonzero;
+pub use nonzero::nonzero;

--- a/oxidized-cuda-kernels/src/nonzero.cu
+++ b/oxidized-cuda-kernels/src/nonzero.cu
@@ -1,0 +1,138 @@
+// This kernel is adapted from the PyTorch nonzero kernel:
+// https://github.com/pytorch/pytorch/blob/81683380633f3c79cbf0debc0d491612b152f202/aten/src/ATen/native/cuda/Nonzero.cu
+//
+// Copyrights and license:
+// https://github.com/pytorch/pytorch/blob/main/LICENSE
+
+#include <cassert>
+#include <cub/cub.cuh>
+
+#include "step_output_iterator.cuh"
+
+#if defined(USE_ROCM)
+constexpr int MAX_DIMS = 16;
+#else
+constexpr int MAX_DIMS = 25;
+#endif
+
+template <typename T>
+struct NonZeroOp
+{
+  __host__ __device__ __forceinline__ bool operator()(const T &a) const
+  {
+    return (a != T(0));
+  }
+};
+
+// TODO: actually support int64_t index_t
+template <typename index_t>
+struct TensorDims
+{
+  index_t sizes[MAX_DIMS];
+};
+
+template <typename index_t>
+__global__ void write_indices(
+    int64_t *inp,
+    TensorDims<index_t> dims,
+    int ndim,
+    index_t n)
+{
+  auto index = threadIdx.x + blockIdx.x * blockDim.x;
+  if (index < n)
+  {
+    index_t div = 1;
+    int64_t idx_flat = inp[index * ndim];
+#pragma unroll
+    for (int dim = MAX_DIMS; dim >= 0; dim--)
+    {
+      if (dim > ndim - 1)
+        continue;
+      auto dim_size = dims.sizes[dim];
+      inp[index * ndim + dim] = (idx_flat / div) % dim_size;
+      div *= dim_size;
+    }
+  }
+}
+
+template <typename scalar_t>
+void nonzero_cuda_impl(size_t const num_elems, size_t const num_dims, size_t const *info,
+                       scalar_t const *input, int64_t **out, size_t *num_nonzeros, cudaStream_t stream = 0)
+{
+  int N = num_elems;
+  // Compute number of nonzero elements.
+  size_t temp_storage_bytes = 0;
+  int *device_num_nonzeros = nullptr;
+  cudaMalloc(&device_num_nonzeros, sizeof(int));
+  cub::TransformInputIterator<bool, NonZeroOp<scalar_t>, const scalar_t *> nonzero_iter(input, NonZeroOp<scalar_t>());
+  cub::DeviceReduce::Sum(nullptr, temp_storage_bytes, nonzero_iter, device_num_nonzeros, N, stream);
+  void *temp_storage = NULL;
+  cudaMalloc(&temp_storage, temp_storage_bytes);
+  cub::DeviceReduce::Sum(temp_storage, temp_storage_bytes, nonzero_iter, device_num_nonzeros, N, stream);
+  cudaFree(temp_storage);
+
+  // Copy the number of nonzero elements to host memory and synchronize.
+  cudaMemcpyAsync(num_nonzeros, device_num_nonzeros, sizeof(int), cudaMemcpyDeviceToHost, stream);
+  cudaStreamSynchronize(stream);
+
+  // Allocate the output, for each non-zero element, we store its index in
+  // each dimension.
+  cudaMalloc(out, num_dims * *num_nonzeros * sizeof(int64_t));
+
+  // Scalars are expected to produce output of size (1,0), so we can't write to it.
+  if (num_dims > 0)
+  {
+    // Get the indices of the non-zero elements, treating the input as an 1D
+    // array. The i-th index is placed at out[i*num_dims], we will later expand
+    // them to xD array indices in out[i*num_dims:(i+1)*num_dims].
+    cub::CountingInputIterator<int64_t> counting_iter(0);
+    StepOutputIterator<int64_t> dims_step_output(*out, num_dims);
+    temp_storage_bytes = 0;
+    cub::DeviceSelect::Flagged(nullptr, temp_storage_bytes, counting_iter, nonzero_iter,
+                               dims_step_output, device_num_nonzeros, N, stream);
+    cudaMalloc(&temp_storage, temp_storage_bytes);
+    cub::DeviceSelect::Flagged(temp_storage, temp_storage_bytes, counting_iter, nonzero_iter,
+                               dims_step_output, device_num_nonzeros, N, stream);
+    cudaFree(temp_storage);
+
+    // Expand the 1D indices to xD array indices if necessary.
+    if (*num_nonzeros > 0 && num_dims > 1)
+    {
+      TensorDims<size_t> dims;
+      for (int i = 0; i < num_dims; i++)
+      {
+        dims.sizes[i] = info[i];
+      }
+      const int nthreads = 256;
+      const int nblocks = (*num_nonzeros + nthreads - 1) / nthreads;
+      write_indices<<<nblocks, nthreads, 0, stream>>>(*out, dims, num_dims, *num_nonzeros);
+      // TODO: verify cudaGetLastError result, or do we do this in Rust-land?
+    }
+  }
+
+  cudaFree(device_num_nonzeros);
+}
+
+template <typename scalar_t>
+void nonzero_cuda(size_t const num_elems, size_t const num_dims, size_t const *info,
+                  scalar_t const *input, int64_t **out, size_t *num_nonzeros, cudaStream_t stream = 0)
+{
+  assert(num_elems < std::numeric_limits<int>::max());
+  assert(num_dims <= MAX_DIMS);
+  nonzero_cuda_impl<scalar_t>(num_elems, num_dims, info, input, out, num_nonzeros, stream);
+}
+
+#define NONZERO_KERNEL(FN_NAME, TYPENAME)                                                                  \
+  extern "C" void FN_NAME(size_t const num_elems, size_t const num_dims, size_t const *info,               \
+                          TYPENAME const *input, int64_t **out, size_t *num_nonzeros, cudaStream_t stream) \
+  {                                                                                                        \
+    nonzero_cuda<TYPENAME>(num_elems, num_dims, info, input, out, num_nonzeros, stream);                   \
+  }
+
+NONZERO_KERNEL(nonzero_bf16, __nv_bfloat16)
+NONZERO_KERNEL(nonzero_f16, __half)
+NONZERO_KERNEL(nonzero_f32, float)
+NONZERO_KERNEL(nonzero_f64, double)
+NONZERO_KERNEL(nonzero_u8, uint8_t)
+NONZERO_KERNEL(nonzero_u32, uint32_t)
+NONZERO_KERNEL(nonzero_i64, int64_t)

--- a/oxidized-cuda-kernels/src/nonzero.rs
+++ b/oxidized-cuda-kernels/src/nonzero.rs
@@ -1,0 +1,111 @@
+use candle_core::{backend::BackendStorage, bail, CudaStorage, DType, Layout, Shape};
+use cudarc::driver::{sys::CUdeviceptr, DevicePtr};
+use half::{bf16, f16};
+
+use crate::ffi;
+
+/// Returns indices of nonzero elements in the given storage.
+///
+/// Fails if the data is not contiguous (C-order).
+pub fn nonzero(
+    storage: &CudaStorage,
+    layout: &Layout,
+) -> Result<(CudaStorage, Shape), candle_core::Error> {
+    if !layout.is_contiguous() {
+        bail!("nonzero kernel requires contiguous layout")
+    }
+
+    let n_elem = layout.shape().elem_count();
+    let n_dim = layout.shape().dims().len();
+    let shape = layout.shape().dims();
+    let stream = storage.device.cu_stream();
+
+    // Kernel outputs
+    let mut n_nonzero = 0;
+    let mut indices: CUdeviceptr = 0;
+
+    let offset = layout.contiguous_offsets().unwrap().0 as CUdeviceptr;
+
+    unsafe {
+        match storage.dtype() {
+            DType::BF16 => ffi::nonzero_bf16(
+                n_elem,
+                n_dim,
+                shape.as_ptr(),
+                (storage.as_cuda_slice::<bf16>().unwrap().device_ptr() + offset) as *const bf16,
+                &mut indices,
+                &mut n_nonzero,
+                *stream,
+            ),
+            DType::F16 => ffi::nonzero_f16(
+                n_elem,
+                n_dim,
+                shape.as_ptr(),
+                (storage.as_cuda_slice::<f16>().unwrap().device_ptr() + offset) as *const f16,
+                &mut indices,
+                &mut n_nonzero,
+                *stream,
+            ),
+            DType::F32 => ffi::nonzero_f32(
+                n_elem,
+                n_dim,
+                shape.as_ptr(),
+                (storage.as_cuda_slice::<f32>().unwrap().device_ptr() + offset) as *const f32,
+                &mut indices,
+                &mut n_nonzero,
+                *stream,
+            ),
+            DType::F64 => ffi::nonzero_f64(
+                n_elem,
+                n_dim,
+                shape.as_ptr(),
+                (storage.as_cuda_slice::<f64>().unwrap().device_ptr() + offset) as *const f64,
+                &mut indices,
+                &mut n_nonzero,
+                *stream,
+            ),
+            DType::U8 => ffi::nonzero_u8(
+                n_elem,
+                n_dim,
+                shape.as_ptr(),
+                (storage.as_cuda_slice::<u8>().unwrap().device_ptr() + offset) as *const u8,
+                &mut indices,
+                &mut n_nonzero,
+                *stream,
+            ),
+            DType::U32 => ffi::nonzero_u32(
+                n_elem,
+                n_dim,
+                shape.as_ptr(),
+                (storage.as_cuda_slice::<u32>().unwrap().device_ptr() + offset) as *const u32,
+                &mut indices,
+                &mut n_nonzero,
+                *stream,
+            ),
+            DType::I64 => ffi::nonzero_i64(
+                n_elem,
+                n_dim,
+                shape.as_ptr(),
+                (storage.as_cuda_slice::<i64>().unwrap().device_ptr() + offset) as *const i64,
+                &mut indices,
+                &mut n_nonzero,
+                *stream,
+            ),
+        }
+    };
+
+    let output_slice = unsafe {
+        storage
+            .device()
+            .upgrade_device_ptr::<i64>(indices, n_nonzero * n_dim)
+    };
+
+    let indices_storage = CudaStorage::wrap_cuda_slice(output_slice, storage.device().clone());
+    let indices_shape = if n_dim == 1 {
+        Shape::from_dims(&[n_nonzero])
+    } else {
+        Shape::from_dims(&[n_nonzero, n_dim])
+    };
+
+    Ok((indices_storage, indices_shape))
+}

--- a/oxidized-cuda-kernels/src/step_output_iterator.cuh
+++ b/oxidized-cuda-kernels/src/step_output_iterator.cuh
@@ -1,0 +1,234 @@
+/******************************************************************************
+ * Copyright (c) 2011, Duane Merrill.  All rights reserved.
+ * Copyright (c) 2011-2018, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2024, The Oxidized Transformers Authors.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+/**
+ * \file
+ * Random-access iterator types
+ */
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#pragma system_header
+#endif // no system header
+
+#include <iostream>
+#include <iterator>
+
+#if (THRUST_VERSION >= 100700)
+// This iterator is compatible with Thrust API 1.7 and newer
+#include <thrust/iterator/iterator_facade.h>
+#include <thrust/iterator/iterator_traits.h>
+#endif // THRUST_VERSION
+
+/**
+ * @brief A random-access output wrapper for storing array values using a PTX cache-modifier.
+ *
+ * @par Overview
+ * - StepOutputIterator is a random-access output iterator that wraps a native
+ *   device pointer of type <tt>ValueType*</tt>. @p ValueType references are
+ *   made by writing @p ValueType values through stores modified by @p MODIFIER.
+ * - Can be used to store any data type to memory using PTX cache store modifiers (e.g., "STORE_WB",
+ *   "STORE_CG", "STORE_CS", "STORE_WT", etc.).
+ * - Can be constructed, manipulated, and exchanged within and between host and device
+ *   functions, but can only be dereferenced within device functions.
+ * - Compatible with Thrust API v1.7 or newer.
+ *
+ * @par Snippet
+ * The code snippet below illustrates the use of @p StepOutputIterator to
+ * dereference a device array of doubles using the "wt" PTX load modifier
+ * (i.e., write-through to system memory).
+ * @par
+ * @code
+ * #include <cub/cub.cuh>   // or equivalently <cub/iterator/cache_modified_output_iterator.cuh>
+ *
+ * // Declare, allocate, and initialize a device array
+ * double *d_out;              // e.g., [, , , , , , ]
+ *
+ * // Create an iterator wrapper
+ * cub::StepOutputIterator<cub::STORE_WT, double> itr(d_out);
+ *
+ * // Within device code:
+ * itr[0]  = 8.0;
+ * itr[1]  = 66.0;
+ * itr[55] = 24.0;
+ *
+ * @endcode
+ *
+ * @par Usage Considerations
+ * - Can only be dereferenced within device code
+ *
+ * @tparam ValueType
+ *   The value type of this iterator
+ *
+ * @tparam OffsetT
+ *   The difference type of this iterator (Default: @p ptrdiff_t)
+ */
+template <
+    typename ValueType,
+    typename OffsetT = ptrdiff_t>
+class StepOutputIterator
+{
+public:
+    // Required iterator traits
+
+    /// My own type
+    typedef StepOutputIterator self_type;
+
+    /// Type to express the result of subtracting one iterator from another
+    typedef OffsetT difference_type;
+
+    /// The type of the element the iterator can point to
+    typedef void value_type;
+
+    /// The type of a pointer to an element the iterator can point to
+    typedef void pointer;
+
+    /// The type of a reference to an element the iterator can point to
+    typedef ValueType &reference;
+
+#if (THRUST_VERSION >= 100700)
+    // Use Thrust's iterator categories so we can use these iterators in Thrust 1.7 (or newer) methods
+
+    /// The iterator category
+    typedef typename THRUST_NS_QUALIFIER::detail::iterator_facade_category<
+        THRUST_NS_QUALIFIER::device_system_tag,
+        THRUST_NS_QUALIFIER::random_access_traversal_tag,
+        value_type,
+        reference>::type iterator_category;
+#else
+    /// The iterator category
+    typedef std::random_access_iterator_tag iterator_category;
+#endif // THRUST_VERSION
+
+private:
+    ValueType *ptr;
+    OffsetT step;
+
+public:
+    /**
+     * @param ptr
+     *   Native pointer to wrap
+     */
+    template <typename QualifiedValueType>
+    __host__ __device__ __forceinline__ StepOutputIterator(QualifiedValueType *ptr, OffsetT step)
+        : ptr(const_cast<typename std::remove_cv<QualifiedValueType>::type *>(ptr)), step(step)
+    {
+    }
+
+    /// Postfix increment
+    __host__ __device__ __forceinline__ self_type operator++(int)
+    {
+        self_type retval = *this;
+        ptr += step;
+        return retval;
+    }
+
+    /// Prefix increment
+    __host__ __device__ __forceinline__ self_type operator++()
+    {
+        ptr += step;
+        return *this;
+    }
+
+    /// Indirection
+    __host__ __device__ __forceinline__ reference operator*() const
+    {
+        return *ptr;
+    }
+
+    /// Addition
+    template <typename Distance>
+    __host__ __device__ __forceinline__ self_type operator+(Distance n) const
+    {
+        self_type retval(ptr + n * step);
+        return retval;
+    }
+
+    /// Addition assignment
+    template <typename Distance>
+    __host__ __device__ __forceinline__ self_type &operator+=(Distance n)
+    {
+        ptr += n * step;
+        return *this;
+    }
+
+    /// Subtraction
+    template <typename Distance>
+    __host__ __device__ __forceinline__ self_type operator-(Distance n) const
+    {
+        self_type retval(ptr - n * step);
+        return retval;
+    }
+
+    /// Subtraction assignment
+    template <typename Distance>
+    __host__ __device__ __forceinline__ self_type &operator-=(Distance n)
+    {
+        ptr -= n * step;
+        return *this;
+    }
+
+    /// Distance
+    __host__ __device__ __forceinline__ difference_type operator-(self_type other) const
+    {
+        return ptr - other.ptr;
+    }
+
+    /// Array subscript
+    template <typename Distance>
+    __host__ __device__ __forceinline__ reference operator[](Distance n) const
+    {
+        return *(ptr + n * step);
+    }
+
+    /// Equal to
+    __host__ __device__ __forceinline__ bool operator==(const self_type &rhs)
+    {
+        return (ptr == rhs.ptr);
+    }
+
+    /// Not equal to
+    __host__ __device__ __forceinline__ bool operator!=(const self_type &rhs)
+    {
+        return (ptr != rhs.ptr);
+    }
+
+    /// ostream operator
+    friend std::ostream &operator<<(std::ostream &os, const self_type &itr)
+    {
+        return os;
+    }
+};

--- a/oxidized-transformers/Cargo.toml
+++ b/oxidized-transformers/Cargo.toml
@@ -13,6 +13,7 @@ candle-core = { workspace = true }
 candle-nn = { workspace = true }
 half = { workspace = true }
 hf-hub = { workspace = true }
+oxidized-cuda-kernels = { workspace = true, optional = true }
 regex = { workspace = true }
 snafu = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -28,6 +29,6 @@ rand_core = { workspace = true }
 
 [features]
 accelerate = ["candle-core/accelerate", "candle-nn/accelerate"]
-cuda = ["candle-core/cuda", "candle-nn/cuda"]
+cuda = ["candle-core/cuda", "candle-nn/cuda", "dep:oxidized-cuda-kernels"]
 cudnn = ["candle-core/cudnn"]
 metal = ["candle-core/metal", "candle-nn/metal"]

--- a/oxidized-transformers/src/lib.rs
+++ b/oxidized-transformers/src/lib.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod kv_cache;
 pub mod layers;
 pub mod models;
+pub mod ops;
 pub mod repository;
 pub mod tokenizers;
 pub mod util;

--- a/oxidized-transformers/src/ops/mod.rs
+++ b/oxidized-transformers/src/ops/mod.rs
@@ -1,0 +1,1 @@
+pub mod nonzero;

--- a/oxidized-transformers/src/ops/nonzero.rs
+++ b/oxidized-transformers/src/ops/nonzero.rs
@@ -1,0 +1,214 @@
+use candle_core::{bail, CpuStorage, CustomOp1, Layout, Shape, Tensor, WithDType};
+use snafu::{ResultExt, Snafu};
+
+#[cfg(feature = "cuda")]
+use candle_core::CudaStorage;
+
+/// Non-zero indices errors.
+#[derive(Debug, Snafu)]
+pub enum NonzeroError {
+    #[snafu(display("Cannot apply nonzero op"))]
+    ApplyOp { source: candle_core::Error },
+
+    #[snafu(display("Failed to make tensor contiguous"))]
+    MakeContiguous { source: candle_core::Error },
+}
+
+/// Get indices of non-zero elements in a tensor.
+pub trait Nonzero {
+    fn nonzero(self) -> Result<Tensor, NonzeroError>;
+}
+
+impl Nonzero for &Tensor {
+    /// Get indices of non-zero elements in a tensor.
+    ///
+    /// Returns a tensor with shape *(n_nonzero, n_dim)* where each row
+    /// contains the index of a non-zero element. If the input is a 1D tensor,
+    /// a tensor with shape *(n_nonzero)* is returned.
+    fn nonzero(self) -> Result<Tensor, NonzeroError> {
+        let contiguous = self.contiguous().context(MakeContiguousSnafu)?;
+        contiguous.apply_op1(NonzeroOp).context(ApplyOpSnafu)
+    }
+}
+
+/// Non-zero indices op.
+///
+/// All op implementations will fail when the input tensor is not contiguous.
+/// The public `Nonzero::nonzero` method takes care of the conversion.
+struct NonzeroOp;
+
+impl NonzeroOp {
+    fn cpu_n_nonzero<T: WithDType>(
+        data: &[T],
+        layout: &Layout,
+    ) -> Result<usize, candle_core::Error> {
+        if !layout.is_contiguous() {
+            bail!("Nonzero op requires contiguous layout")
+        }
+
+        let (start_offset, end_offset) = layout.contiguous_offsets().unwrap();
+
+        let n_nonzero = data[start_offset..end_offset]
+            .iter()
+            .filter(|x| !x.is_zero())
+            .count();
+
+        Ok(n_nonzero)
+    }
+
+    fn cpu_fwd_impl<T: WithDType>(
+        &self,
+        data: &[T],
+        layout: &Layout,
+    ) -> Result<(CpuStorage, Shape), candle_core::Error> {
+        if !layout.is_contiguous() {
+            bail!("Nonzero op requires contiguous layout")
+        }
+
+        let n_nonzero = Self::cpu_n_nonzero(data, layout)?;
+        let n_dim = layout.dims().len();
+
+        let mut dst = Vec::with_capacity(n_nonzero * n_dim);
+        let dst_to_set = dst.spare_capacity_mut();
+        let dst_to_set = unsafe { std::mem::transmute::<_, &mut [i64]>(dst_to_set) };
+
+        let (start_offset, end_offset) = layout.contiguous_offsets().unwrap();
+
+        let data = &data[start_offset..end_offset];
+        let mut offset = 0;
+        for (idx, val) in data.iter().enumerate() {
+            if !val.is_zero() {
+                let mut div = 1;
+                for (dim, dim_size) in layout.dims().iter().enumerate().rev() {
+                    dst_to_set[offset + dim] = ((idx / div) % dim_size) as i64;
+                    div *= dim_size;
+                }
+                offset += n_dim;
+            }
+
+            // Don't process any remaining zero entries when we know
+            // that we are done.
+            if offset == n_nonzero * n_dim {
+                break;
+            }
+        }
+        unsafe { dst.set_len(n_nonzero * n_dim) }
+
+        let shape = if layout.dims().len() == 1 {
+            Shape::from_dims(&[n_nonzero])
+        } else {
+            Shape::from_dims(&[n_nonzero, n_dim])
+        };
+
+        Ok((CpuStorage::I64(dst), shape))
+    }
+}
+
+impl CustomOp1 for NonzeroOp {
+    fn name(&self) -> &'static str {
+        "nonzero"
+    }
+
+    fn cpu_fwd(
+        &self,
+        storage: &CpuStorage,
+        layout: &Layout,
+    ) -> Result<(CpuStorage, Shape), candle_core::Error> {
+        match storage {
+            CpuStorage::U8(data) => self.cpu_fwd_impl(data, layout),
+            CpuStorage::U32(data) => self.cpu_fwd_impl(data, layout),
+            CpuStorage::I64(data) => self.cpu_fwd_impl(data, layout),
+            CpuStorage::BF16(data) => self.cpu_fwd_impl(data, layout),
+            CpuStorage::F16(data) => self.cpu_fwd_impl(data, layout),
+            CpuStorage::F32(data) => self.cpu_fwd_impl(data, layout),
+            CpuStorage::F64(data) => self.cpu_fwd_impl(data, layout),
+        }
+    }
+
+    #[cfg(feature = "cuda")]
+    fn cuda_fwd(
+        &self,
+        storage: &CudaStorage,
+        layout: &Layout,
+    ) -> Result<(CudaStorage, Shape), candle_core::Error> {
+        if !layout.is_contiguous() {
+            bail!("Nonzero op requires contiguous layout")
+        }
+
+        oxidized_cuda_kernels::nonzero(storage, layout)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use candle_core::{DType, Tensor};
+    use ndarray::{array, ArrayD};
+    use snafu::{report, ResultExt, Whatever};
+
+    use crate::{
+        ops::nonzero::Nonzero,
+        util::{device::tests::test_devices, tests::IntoArrayD},
+    };
+
+    #[test]
+    #[report]
+    fn nonzero_produces_correct_output() -> Result<(), Whatever> {
+        for device in test_devices() {
+            // We do not have a Metal kernel yet.
+            if device.is_metal() {
+                continue;
+            }
+
+            for dtype in &[DType::F16, DType::BF16, DType::F32, DType::I64] {
+                // Check 1D tensor.
+                let t = Tensor::from_slice(&[1.0, 0.0, 2.0, 0.0, 3.0, 0.0], &[6], &device)
+                    .unwrap()
+                    .to_dtype(dtype.clone())
+                    .unwrap();
+                let r: ArrayD<i64> = t
+                    .nonzero()
+                    .whatever_context("Cannot compute non-zero indices")?
+                    .into_arrayd()
+                    .whatever_context("Cannot convert indices to array")?;
+                assert_eq!(r, array![0, 2, 4].into_arrayd().unwrap());
+
+                // Check 2D tensor.
+                let t = Tensor::eye(3, dtype.clone(), &device).unwrap();
+                let r: ArrayD<i64> = t.nonzero().unwrap().into_arrayd().unwrap();
+                assert_eq!(r, array![[0i64, 0], [1, 1], [2, 2]].into_arrayd().unwrap());
+
+                // Check non-contiguous tensor.
+                let t = t.t().unwrap();
+                let r: ArrayD<i64> = t
+                    .nonzero()
+                    .whatever_context("Cannot compute non-zero indices")?
+                    .into_arrayd()
+                    .whatever_context("Cannot convert indices to array")?;
+                assert_eq!(r, array![[0i64, 0], [1, 1], [2, 2]].into_arrayd().unwrap());
+
+                // Check 3D tensorr.
+                let t = Tensor::from_slice(
+                    &[1.0, 0.0, 2.0, 0.0, 3.0, 0.0, 4.0, 0.0],
+                    &[2, 2, 2],
+                    &device,
+                )
+                .unwrap()
+                .to_dtype(dtype.clone())
+                .unwrap();
+                let r: ArrayD<i64> = t
+                    .nonzero()
+                    .whatever_context("Cannot compute non-zero indices")?
+                    .into_arrayd()
+                    .whatever_context("Cannot convert indices to array")?;
+                assert_eq!(
+                    r,
+                    array![[0i64, 0, 0], [0, 1, 0], [1, 0, 0], [1, 1, 0]]
+                        .into_arrayd()
+                        .unwrap()
+                );
+            }
+        }
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This trait works the same as `torch.nonzero`, it returns for a given tensor the indices of the non-zero values.

This function is currently only implemented for CPU and CUDA. I will look into a Metal kernel later. For the time being we will only use this for setting up flash attention, so we don't need it on Metal yet anyway.