### PR TITLE
Add support for using flash attention in SDPA

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,9 @@ repository = "https://github.com/oxidized-transformers/oxidized-transformers"
 
 [workspace.dependencies]
 approx = "0.5"
-candle-core = "0.4"
-candle-nn = "0.4"
+candle-core = { git = "https://github.com/huggingface/candle.git", revision = "fc1fe5e" }
+candle-flash-attn = { git = "https://github.com/huggingface/candle.git", revision = "fc1fe5e" }
+candle-nn = { git = "https://github.com/huggingface/candle.git", revision = "fc1fe5e" }
 cudarc = { version = "0.10.0", features = ["f16"] }
 half = "2.4"
 hf-hub = "0.3"

--- a/oxidized-cuda-kernels/Cargo.toml
+++ b/oxidized-cuda-kernels/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT or Apache-2.0"
 repository = "https://github.com/oxidized-transformers/oxidized-transformers"
 
 [dependencies]
-candle-core = { version = "0.4", features = ["cuda"] }
+candle-core = { git = "https://github.com/huggingface/candle.git", revision = "fc1fe5e" }
 cudarc = { version = "0.10", features = ["f16"] }
 half = "2.4"
 

--- a/oxidized-transformers/Cargo.toml
+++ b/oxidized-transformers/Cargo.toml
@@ -10,6 +10,7 @@ homepage.workspace = true
 
 [dependencies]
 candle-core = { workspace = true }
+candle-flash-attn = { workspace = true, optional = true }
 candle-nn = { workspace = true }
 half = { workspace = true }
 hf-hub = { workspace = true }
@@ -31,4 +32,5 @@ rand_core = { workspace = true }
 accelerate = ["candle-core/accelerate", "candle-nn/accelerate"]
 cuda = ["candle-core/cuda", "candle-nn/cuda", "dep:oxidized-cuda-kernels"]
 cudnn = ["candle-core/cudnn"]
+flash-attn = ["cuda", "dep:candle-flash-attn"]
 metal = ["candle-core/metal", "candle-nn/metal"]

--- a/oxidized-transformers/src/layers/attention/alibi.rs
+++ b/oxidized-transformers/src/layers/attention/alibi.rs
@@ -180,6 +180,14 @@ impl AttentionLinearBiases {
 
         attention_scores.add(&biases).context(ApplyBiasesSnafu)
     }
+
+    /// Get the ALiBi slopes.
+    ///
+    /// Returns: Slopes tensor.
+    /// *Shape:* `(1, heads, 1, 1)`
+    pub fn slopes(&self) -> &Tensor {
+        &self.slopes
+    }
 }
 
 #[cfg(test)]

--- a/oxidized-transformers/src/layers/attention/mod.rs
+++ b/oxidized-transformers/src/layers/attention/mod.rs
@@ -7,9 +7,7 @@ mod mask;
 pub use mask::{AttentionMask, AttentionMaskError};
 
 mod sdpa;
-pub use sdpa::{
-    ScaledDotProductAttention, ScaledDotProductAttentionConfig, ScaledDotProductAttentionError,
-};
+pub use sdpa::{with_sdpa_implementation, SDPAConfig, SDPAError, SDPAImplementation, SDPA};
 
 mod alibi;
 pub use alibi::{AttentionLinearBiases, AttentionLinearBiasesConfig, AttentionLinearBiasesError};
@@ -69,6 +67,8 @@ pub trait AttentionScorer {
     /// * `attention_mask` - Attention mask. Sequence elements for which
     ///   the corresponding mask element is set to `false` are ignored in attention.
     /// * `train` - Whether the model is trained.
+    /// * `use_causal_mask` - Whether to apply a causal mask. With a causal mask,
+    ///   a sequence element can only attend to preceding elements and itself.
     ///
     /// Returns: Attention values.
     /// *Shape:* `(batch_size, heads, seq_len, width)`
@@ -77,8 +77,9 @@ pub trait AttentionScorer {
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
-        attention_mask: &SelfAttentionMask,
+        attention_mask: &AttentionMask,
         train: bool,
+        use_causal_mask: bool,
     ) -> Result<Tensor, BoxedError>;
 }
 

--- a/oxidized-transformers/src/layers/attention/sdpa.rs
+++ b/oxidized-transformers/src/layers/attention/sdpa.rs
@@ -1,3 +1,5 @@
+use std::cell::Cell;
+
 use candle_core::{ModuleT, Tensor, D};
 use candle_nn::ops::softmax;
 use candle_nn::VarBuilder;
@@ -6,20 +8,52 @@ use snafu::{ResultExt, Snafu};
 use crate::error::BoxedError;
 use crate::layers::attention::self_attention::{SelfAttentionMask, SelfAttentionMaskError};
 use crate::layers::attention::{
-    AttentionLinearBiases, AttentionLinearBiasesConfig, AttentionLinearBiasesError,
-    AttentionScorer, BuildAttentionScorer,
+    AttentionLinearBiases, AttentionLinearBiasesConfig, AttentionLinearBiasesError, AttentionMask,
+    AttentionScorer, BuildAttentionScorer, CausalMaskError,
 };
+use crate::layers::attention::{AttentionMaskError, CausalMask};
 use crate::layers::build_module::BuildModule;
 use crate::layers::identity::Identity;
+use crate::ops::nonzero::NonzeroError;
+
+#[cfg(feature = "flash-attn")]
+use candle_core::DType;
+
+/// Scaled dot product attention implementation.
+#[derive(Debug, Clone, Copy)]
+pub enum SDPAImplementation {
+    /// Default implementation.
+    Default,
+
+    /// Flash attention.
+    ///
+    /// Flash attention will only be used if the model is on a CUDA device
+    /// and the input is of type `BF16` or `F16`.
+    Flash,
+}
+
+thread_local! {
+    static SDPA_IMPLEMENTATION: Cell<SDPAImplementation> = const { Cell::new(SDPAImplementation::Default) };
+}
+
+/// Run a closure with a specific scaled dot-product attention implementation.
+pub fn with_sdpa_implementation<T>(implementation: SDPAImplementation, f: impl FnOnce() -> T) -> T {
+    SDPA_IMPLEMENTATION.with(|sdpa_implementation| {
+        let prev = sdpa_implementation.replace(implementation);
+        let result = f();
+        sdpa_implementation.replace(prev);
+        result
+    })
+}
 
 /// Configuration for scaled dot-product attention.
 #[derive(Debug)]
-pub struct ScaledDotProductAttentionConfig {
+pub struct SDPAConfig {
     dropout: Box<dyn BuildModule>,
     linear_biases: Option<AttentionLinearBiasesConfig>,
 }
 
-impl ScaledDotProductAttentionConfig {
+impl SDPAConfig {
     /// Dropout to apply after attention.
     ///
     /// Default: `Identity`.
@@ -37,7 +71,7 @@ impl ScaledDotProductAttentionConfig {
     }
 }
 
-impl Default for ScaledDotProductAttentionConfig {
+impl Default for SDPAConfig {
     fn default() -> Self {
         Self {
             dropout: Box::new(Identity),
@@ -46,9 +80,9 @@ impl Default for ScaledDotProductAttentionConfig {
     }
 }
 
-impl BuildAttentionScorer for ScaledDotProductAttentionConfig {
+impl BuildAttentionScorer for SDPAConfig {
     fn build(&self, vb: VarBuilder) -> Result<Box<dyn AttentionScorer>, BoxedError> {
-        Ok(Box::new(ScaledDotProductAttention {
+        Ok(Box::new(SDPA {
             dropout: self.dropout.build(vb.clone()).context(BuildDropoutSnafu)?,
             linear_biases: self
                 .linear_biases
@@ -62,12 +96,12 @@ impl BuildAttentionScorer for ScaledDotProductAttentionConfig {
 
 /// Errors for scaled dot-product attention.
 #[derive(Debug, Snafu)]
-pub enum ScaledDotProductAttentionError {
+pub enum SDPAError {
     #[snafu(display("Cannot calculate attention linear biases"))]
     AttentionLinearBiases { source: AttentionLinearBiasesError },
 
     #[snafu(display("Cannot apply attention mask"))]
-    AttentionMask { source: SelfAttentionMaskError },
+    AttentionMask { source: AttentionMaskError },
 
     #[snafu(display("Cannot calculate attention scores"))]
     AttentionScores { source: candle_core::Error },
@@ -81,30 +115,84 @@ pub enum ScaledDotProductAttentionError {
     #[snafu(display("Cannot build dropout module"))]
     BuildDropout { source: BoxedError },
 
+    #[snafu(display("Cannot create causal mask"))]
+    CausalMask { source: CausalMaskError },
+
+    #[snafu(display("Cannot apply dropout"))]
+    Dropout { source: candle_core::Error },
+
+    #[snafu(display("Cannot apply flash attention"))]
+    FlashAttention { source: candle_core::Error },
+
+    #[snafu(display("Cannot calculate indices of tokens that are not masked"))]
+    NonzeroIndices { source: NonzeroError },
+
+    #[snafu(display("Cannot pad heads"))]
+    PadHeads { source: candle_core::Error },
+
+    #[snafu(display("Cannot update self-attention mask"))]
+    SelfAttentionMask { source: SelfAttentionMaskError },
+
+    #[snafu(display("Cannot calculate sequence lengths"))]
+    SeqLens { source: candle_core::Error },
+
     #[snafu(display("Cannot apply softmax temperature"))]
     Temperature { source: candle_core::Error },
+
+    #[snafu(display("Cannot unpad heads"))]
+    UnpadHeads { source: candle_core::Error },
 }
 
 /// Scaled dot-product attention.
 ///
 /// See [Vaswani et al., 2017](https://arxiv.org/abs/1706.03762).
-pub struct ScaledDotProductAttention {
+pub struct SDPA {
     dropout: Box<dyn ModuleT>,
     linear_biases: Option<AttentionLinearBiases>,
 }
 
-impl AttentionScorer for ScaledDotProductAttention {
+impl AttentionScorer for SDPA {
     fn forward(
         &self,
         query: &Tensor,
         key: &Tensor,
         value: &Tensor,
-        attention_mask: &SelfAttentionMask,
+        attention_mask: &AttentionMask,
         train: bool,
+        use_causal_mask: bool,
     ) -> Result<Tensor, BoxedError> {
-        // TODO: add code path for flash attention, but verify the attention
-        //       layer is working first...
+        let output = match SDPA_IMPLEMENTATION.get() {
+            #[cfg(feature = "flash-attn")]
+            SDPAImplementation::Flash if Self::is_flash_attention_supported(key) => self
+                .forward_flash_attn(query, key, value, attention_mask, use_causal_mask)
+                .boxed(),
+            _ => self.forward_default(query, key, value, attention_mask, use_causal_mask),
+        }?;
+        self.dropout
+            .forward_t(&output, train)
+            .context(DropoutSnafu)
+            .boxed()
+    }
+}
 
+impl SDPA {
+    /// Check whether flash attention is supported.
+    #[cfg(feature = "flash-attn")]
+    fn is_flash_attention_supported(xs: &Tensor) -> bool {
+        xs.device().is_cuda() && (xs.dtype() == DType::BF16 || xs.dtype() == DType::F16)
+    }
+
+    /// Default/reference implementation.
+    ///
+    /// For docs see the `AttentionScorer` trait.
+    fn forward_default(
+        &self,
+        query: &Tensor,
+        key: &Tensor,
+        value: &Tensor,
+        attention_mask: &AttentionMask,
+        use_causal_mask: bool,
+    ) -> Result<Tensor, BoxedError> {
         // Calculate attention scores.
         let query = query.contiguous().context(AttentionScoresSnafu)?;
         let mut attn_scores = key
@@ -124,17 +212,230 @@ impl AttentionScorer for ScaledDotProductAttention {
                 .context(AttentionLinearBiasesSnafu)?;
         }
 
-        attn_scores = attention_mask
+        let mut combined_mask: SelfAttentionMask = attention_mask.into();
+        if use_causal_mask {
+            let causal_mask =
+                SelfAttentionMask::causal_mask(&query, key).context(CausalMaskSnafu)?;
+            combined_mask = combined_mask
+                .intersect(&causal_mask)
+                .context(SelfAttentionMaskSnafu)?;
+        }
+
+        attn_scores = combined_mask
             .apply_logit_mask(&attn_scores)
-            .context(AttentionMaskSnafu)?;
+            .context(SelfAttentionMaskSnafu)?;
 
         // Apply attention weights.
         let attn_weights = softmax(&attn_scores, D::Minus1).context(AttentionWeightSnafu)?;
         value
             .contiguous()
             .and_then(|value| attn_weights.broadcast_matmul(&value))
-            .and_then(|xs| self.dropout.forward_t(&xs, train))
             .context(AttentionWeightSnafu)
             .boxed()
+    }
+
+    /// Flash attention implementation.
+    ///
+    /// For docs see the `AttentionScorer` trait.
+    #[cfg(feature = "flash-attn")]
+    fn forward_flash_attn(
+        &self,
+        query: &Tensor,
+        key: &Tensor,
+        value: &Tensor,
+        attention_mask: &AttentionMask,
+        use_causal_mask: bool,
+    ) -> Result<Tensor, SDPAError> {
+        use candle_flash_attn::{flash_attn_varlen, flash_attn_varlen_alibi};
+
+        let (_batch_size, _kv_heads, key_value_len, head_width) =
+            key.dims4().context(FlashAttentionSnafu)?;
+        let (_batch_size, _q_heads, query_len, _query_width) =
+            query.dims4().context(FlashAttentionSnafu)?;
+
+        let softmax_scale = 1.0 / (head_width as f32).sqrt();
+
+        let (key_unpad, key_indices) = Self::unpad_heads(key, attention_mask, None)?;
+        let (value_unpad, _) = Self::unpad_heads(value, attention_mask, Some(&key_indices))?;
+        let query_mask = AttentionMask::new(
+            attention_mask
+                .bool_mask
+                .narrow(1, key_value_len - query_len, query_len)
+                .context(FlashAttentionSnafu)?,
+        )
+        .context(AttentionMaskSnafu)?;
+        let query_indices = if query_len == key_value_len {
+            Some(&key_indices)
+        } else {
+            None
+        };
+        let (query_unpad, query_indices) = Self::unpad_heads(query, &query_mask, query_indices)?;
+
+        let key_value_lens = Self::seq_lens_flash_attn(attention_mask)?;
+        let query_lens = if query_len == key_value_len {
+            key_value_lens.clone()
+        } else {
+            Self::seq_lens_flash_attn(&query_mask)?
+        };
+
+        let query_max_len = query_lens
+            .max(0)
+            .and_then(|maxlen| maxlen.to_scalar::<u32>())
+            .context(FlashAttentionSnafu)? as usize;
+        let key_value_max_len = key_value_lens
+            .max(0)
+            .and_then(|maxlen| maxlen.to_scalar::<u32>())
+            .context(FlashAttentionSnafu)? as usize;
+
+        let output_unpad = match &self.linear_biases {
+            Some(linear_biases) => flash_attn_varlen_alibi(
+                &query_unpad,
+                &key_unpad,
+                &value_unpad,
+                &linear_biases
+                    .slopes()
+                    .reshape(((),))
+                    .context(FlashAttentionSnafu)?,
+                &query_lens,
+                &key_value_lens,
+                query_max_len,
+                key_value_max_len,
+                softmax_scale,
+                use_causal_mask,
+            ),
+            None => flash_attn_varlen(
+                &query_unpad,
+                &key_unpad,
+                &value_unpad,
+                &query_lens,
+                &key_value_lens,
+                query_max_len,
+                key_value_max_len,
+                softmax_scale,
+                use_causal_mask,
+            ),
+        }
+        .context(FlashAttentionSnafu)?;
+
+        Self::pad_heads(&output_unpad, &query_mask, &query_indices)
+    }
+
+    /// Compute the sequence lengths from the attention masks.
+    ///
+    /// This ignores any pieces that are masked out.
+    #[cfg(feature = "flash-attn")]
+    fn seq_lens(attention_mask: &AttentionMask) -> Result<Tensor, SDPAError> {
+        attention_mask
+            .bool_mask()
+            // Mask is U8, which will overflow for longer sequences.
+            .to_dtype(DType::U32)
+            .and_then(|mask| mask.sum(D::Minus1))
+            .context(SeqLensSnafu)
+    }
+
+    /// Compute the sequence lengths for flash attention.
+    ///
+    /// This method is similar to [`Self::seq_lens`], but prepares the
+    /// sequence lengths for the flash attention implementation:
+    ///
+    /// * Compute the cumulative sum.
+    /// * Prepend a zero to cumulative sum.
+    ///
+    /// As a result, the tensor can be used as starting/ending indices
+    /// into the tensor that stores the sequences.
+    #[cfg(feature = "flash-attn")]
+    fn seq_lens_flash_attn(attention_mask: &AttentionMask) -> Result<Tensor, SDPAError> {
+        let seq_lens = Self::seq_lens(attention_mask)?
+            // Candle cumsum currently only works on floating point types.
+            .to_dtype(DType::F32)
+            .and_then(|seq_lens| seq_lens.cumsum(0))
+            .and_then(|seq_lens| seq_lens.to_dtype(DType::U32))
+            .context(SeqLensSnafu)?;
+
+        // Prepend a zero to the sequence lengths.
+        Tensor::zeros(&[1], seq_lens.dtype(), seq_lens.device())
+            .and_then(|zeros| Tensor::cat(&[&zeros, &seq_lens], 0))
+            .context(SeqLensSnafu)
+    }
+
+    /// Add padding to the head representations.
+    ///
+    /// This helper function takes an input of the shape `(n_pieces, n_heads,
+    /// hidden_size)` and transforms it into a representation with shape
+    /// `(batch_size, n_heads, seq_len, hidden_size)` by padding all sequences
+    /// to the same length using the provided indices.
+    #[cfg(feature = "flash-attn")]
+    fn pad_heads(
+        heads: &Tensor,
+        attention_mask: &AttentionMask,
+        indices: &Tensor,
+    ) -> Result<Tensor, SDPAError> {
+        let (batch_size, seq_len) = attention_mask.bool_mask().dims2().context(PadHeadsSnafu)?;
+        let (n_indices, n_heads, hidden_width) = heads.dims3().context(PadHeadsSnafu)?;
+
+        let expanded_indices = indices
+            .expand((n_indices, n_heads, hidden_width))
+            .and_then(|indices| indices.contiguous())
+            .context(PadHeadsSnafu)?;
+
+        Tensor::zeros(
+            &[batch_size * seq_len, n_heads, hidden_width],
+            heads.dtype(),
+            heads.device(),
+        )
+        .and_then(|zeros| zeros.scatter_add(&expanded_indices, &heads, 0))
+        // Restore original, non-flash-attention shape.
+        .and_then(|padded| padded.reshape((batch_size, seq_len, n_heads, hidden_width)))
+        .and_then(|padded| padded.transpose(1, 2))
+        .context(PadHeadsSnafu)
+    }
+
+    /// Remove padding from the head representations.
+    ///
+    /// This helper function takes an input of the shape `(batch_size, n_heads,
+    /// seq_len, hidden_size)` and transforms it into a representation with
+    /// shape `(n_pieces, n_heads, hidden_size)`, where all padding pieces are
+    /// removed using the attention mask.
+    ///
+    /// The indices can be provided optionally to avoid recomputing the indices
+    /// from the attention mask.
+    #[cfg(feature = "flash-attn")]
+    fn unpad_heads(
+        heads: &Tensor,
+        attention_mask: &AttentionMask,
+        indices: Option<&Tensor>,
+    ) -> Result<(Tensor, Tensor), SDPAError> {
+        use crate::ops::nonzero::Nonzero;
+
+        let (batch_size, n_heads, seq_len, hidden_width) =
+            heads.dims4().context(UnpadHeadsSnafu)?;
+
+        let indices = match indices {
+            Some(indices) => indices.clone(),
+            None => attention_mask
+                .bool_mask()
+                .reshape(((),))
+                .context(UnpadHeadsSnafu)?
+                .nonzero()
+                .context(NonzeroIndicesSnafu)?
+                .reshape(((), 1, 1))
+                .context(UnpadHeadsSnafu)?,
+        };
+
+        let n_indices = indices.dim(0).context(UnpadHeadsSnafu)?;
+
+        let expanded_indices = indices
+            .expand((n_indices, n_heads, hidden_width))
+            .and_then(|indices| indices.contiguous())
+            .context(UnpadHeadsSnafu)?;
+
+        Ok((
+            heads
+                .transpose(1, 2)
+                .and_then(|heads| heads.reshape((batch_size * seq_len, n_heads, hidden_width)))
+                .and_then(|heads| heads.gather(&expanded_indices, 0))
+                .context(UnpadHeadsSnafu)?,
+            indices,
+        ))
     }
 }

--- a/oxidized-transformers/src/models/albert/encoder.rs
+++ b/oxidized-transformers/src/models/albert/encoder.rs
@@ -12,7 +12,7 @@ use crate::architectures::{
 use crate::error::BoxedError;
 use crate::layers::activation::Activation;
 use crate::layers::attention::{
-    AttentionHeads, AttentionMask, QkvMode, ScaledDotProductAttentionConfig, SelfAttentionConfig,
+    AttentionHeads, AttentionMask, QkvMode, SDPAConfig, SelfAttentionConfig,
 };
 use crate::layers::dropout::DropoutConfig;
 use crate::layers::feedforward::PointwiseFeedForwardConfig;
@@ -95,7 +95,7 @@ impl TryFrom<HFAlbertEncoderConfig> for AlbertEncoderConfig {
                 qkv_mode: QkvMode::Separate,
             })
             .attention_scorer(Box::new(
-                ScaledDotProductAttentionConfig::default().dropout(attention_probs_dropout),
+                SDPAConfig::default().dropout(attention_probs_dropout),
             ))
             .hidden_width(hf_config.hidden_size);
 

--- a/oxidized-transformers/src/models/bert/encoder.rs
+++ b/oxidized-transformers/src/models/bert/encoder.rs
@@ -5,9 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::BoxedError;
 use crate::layers::activation::Activation;
-use crate::layers::attention::{
-    AttentionHeads, QkvMode, ScaledDotProductAttentionConfig, SelfAttentionConfig,
-};
+use crate::layers::attention::{AttentionHeads, QkvMode, SDPAConfig, SelfAttentionConfig};
 use crate::layers::dropout::DropoutConfig;
 use crate::layers::feedforward::PointwiseFeedForwardConfig;
 use crate::layers::layer_norm::LayerNormConfig;
@@ -75,7 +73,7 @@ impl TryFrom<HFBertEncoderConfig> for TransformerEncoderConfig {
                 qkv_mode: QkvMode::Separate,
             })
             .attention_scorer(Box::new(
-                ScaledDotProductAttentionConfig::default().dropout(attention_probs_dropout),
+                SDPAConfig::default().dropout(attention_probs_dropout),
             ))
             .hidden_width(hf_config.hidden_size);
 

--- a/oxidized-transformers/src/models/llama/decoder.rs
+++ b/oxidized-transformers/src/models/llama/decoder.rs
@@ -166,10 +166,24 @@ mod tests {
     #[test]
     #[report]
     fn llama_decoder_give_correct_output_with_cache() -> Result<(), Whatever> {
-        check_decoder_with_cache::<LlamaDecoder, _>(
+        check_decoder_with_cache!(
+            LlamaDecoder,
             "explosion-testing/llama2-kv-sharing",
             None,
-            array![[-7.3655], [-11.2087], [-1.9727]],
+            array![[0.0], [-11.2087], [0.0]],
+            epsilon = 1e-4,
+        )
+    }
+
+    #[test]
+    #[report]
+    fn llama_decoder_give_correct_output_with_cache_float16() -> Result<(), Whatever> {
+        check_decoder_with_cache!(
+            LlamaDecoder,
+            "explosion-testing/llama2-kv-sharing-float16",
+            None,
+            array![[0.0], [-11.223126], [0.0]],
+            epsilon = 1e-1,
         )
     }
 }

--- a/oxidized-transformers/src/models/roberta/encoder.rs
+++ b/oxidized-transformers/src/models/roberta/encoder.rs
@@ -5,9 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::BoxedError;
 use crate::layers::activation::Activation;
-use crate::layers::attention::{
-    AttentionHeads, QkvMode, ScaledDotProductAttentionConfig, SelfAttentionConfig,
-};
+use crate::layers::attention::{AttentionHeads, QkvMode, SDPAConfig, SelfAttentionConfig};
 use crate::layers::dropout::DropoutConfig;
 use crate::layers::feedforward::PointwiseFeedForwardConfig;
 use crate::layers::layer_norm::LayerNormConfig;
@@ -83,7 +81,7 @@ impl TryFrom<HFRobertaEncoderConfig> for TransformerEncoderConfig {
                 qkv_mode: QkvMode::Separate,
             })
             .attention_scorer(Box::new(
-                ScaledDotProductAttentionConfig::default().dropout(attention_probs_dropout),
+                SDPAConfig::default().dropout(attention_probs_dropout),
             ))
             .hidden_width(hf_config.hidden_size);
 

--- a/oxidized-transformers/src/models/util.rs
+++ b/oxidized-transformers/src/models/util.rs
@@ -6,7 +6,7 @@ pub(crate) mod tests {
 
     use crate::architectures::{CausalLM, Decoder, Encoder, LayerOutputs};
     use crate::kv_cache::KeyValueCache;
-    use crate::layers::attention::AttentionMask;
+    use crate::layers::attention::{with_sdpa_implementation, AttentionMask, SDPAImplementation};
     use crate::models::hf::FromHFHub;
     use crate::util::device::tests::test_devices;
     use crate::util::tests::{assert_tensor_eq, IntoArrayD, PseudoRandomReduction};
@@ -73,36 +73,40 @@ pub(crate) mod tests {
             .whatever_context("Cannot convert tensor")?;
 
         for device in test_devices() {
-            let causal_lm = C::from_hf_hub(model_name, model_revision, &device)
-                .whatever_context("Cannot load causal language model")?;
+            for sdpa_impl in &[SDPAImplementation::Default, SDPAImplementation::Flash] {
+                let causal_lm = C::from_hf_hub(model_name, model_revision, &device)
+                    .whatever_context("Cannot load causal language model")?;
 
-            let (input, mask) = sample_transformer_inputs(&device)?;
+                let (input, mask) = sample_transformer_inputs(&device)?;
 
-            let output = causal_lm
-                .forward_t(&input, &mask, &mut KeyValueCache::no_cache(), None, false)
-                .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))?;
+                let output = with_sdpa_implementation(*sdpa_impl, || {
+                    causal_lm
+                        .forward_t(&input, &mask, &mut KeyValueCache::no_cache(), None, false)
+                        .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))
+                })?;
 
-            let (batch_size, seq_len, n_class) = output
-                .logits()
-                .shape()
-                .dims3()
-                .whatever_context("Cannot get logits shape")?;
-            let logits = mask
-                .bool_mask()
-                .unsqueeze(D::Minus1)
-                .and_then(|mask| mask.to_dtype(output.logits().dtype()))
-                .and_then(|mask| mask.expand(&[batch_size, seq_len, n_class]))
-                .and_then(|mask| output.logits() * mask)
-                .whatever_context("Cannot mask out logits")?;
+                let (batch_size, seq_len, n_class) = output
+                    .logits()
+                    .shape()
+                    .dims3()
+                    .whatever_context("Cannot get logits shape")?;
+                let logits = mask
+                    .bool_mask()
+                    .unsqueeze(D::Minus1)
+                    .and_then(|mask| mask.to_dtype(output.logits().dtype()))
+                    .and_then(|mask| mask.expand(&[batch_size, seq_len, n_class]))
+                    .and_then(|mask| output.logits() * mask)
+                    .whatever_context("Cannot mask out logits")?;
 
-            assert_tensor_eq!(
-                logits
-                    .pseudo_random_reduction()
-                    .whatever_context("Cannot apply reduction using random vector")?,
-                test_tensor.view(),
-                epsilon = relative.epsilon,
-                max_relative = relative.max_relative,
-            );
+                assert_tensor_eq!(
+                    logits
+                        .pseudo_random_reduction()
+                        .whatever_context("Cannot apply reduction using random vector")?,
+                    test_tensor.view(),
+                    epsilon = relative.epsilon,
+                    max_relative = relative.max_relative,
+                );
+            }
         }
 
         Ok(())
@@ -155,16 +159,29 @@ pub(crate) mod tests {
         Ok(())
     }
 
+    /// This macro accepts the optional `epsilon` and `max_relative` arguments
+    /// for specifying the absolute and relative tolerances for the comparison.
+    macro_rules! check_decoder_with_cache {
+        ($model_type:ty, $model_name:expr, $model_revision:expr, $test_tensor:expr $(, $opt:ident = $val:expr)*) => {
+            crate::models::util::tests::check_decoder_with_cache_::<$model_type, _>($model_name, $model_revision, $test_tensor, approx::Relative::default()$(.$opt($val))*)
+        };
+        ($model_type:ty, $model_name:expr, $model_revision:expr, $test_tensor:expr $(, $opt:ident = $val:expr)*,) => {
+            crate::models::util::tests::check_decoder_with_cache_::<$model_type, _>($model_name, $model_revision, $test_tensor, approx::Relative::default()$(.$opt($val))*)
+        };
+    }
+    pub(crate) use check_decoder_with_cache;
+
     /// Check decoder with cache against test vectors.
     ///
     /// * `model_name` - The name of the model to test.
     /// * `model_revision` - The revision of the model to test.
     /// * `test_tensor` - The expected output tensor.
     ///   Shape: `(batch_size, sequence_length)`.
-    pub fn check_decoder_with_cache<D, M>(
+    pub fn check_decoder_with_cache_<D, M>(
         model_name: &str,
         model_revision: Option<&str>,
         test_tensor: impl IntoArrayD<f32>,
+        relative: Relative<f32>,
     ) -> Result<(), Whatever>
     where
         D: FromHFHub<Model = M>,
@@ -174,68 +191,82 @@ pub(crate) mod tests {
             .into_arrayd()
             .whatever_context("Cannot convert tensor")?;
 
-        for device in test_devices() {
-            let decoder = D::from_hf_hub(model_name, model_revision, &device)
-                .whatever_context("Cannot load decoder")?;
+        for sdpa_impl in &[SDPAImplementation::Default, SDPAImplementation::Flash] {
+            for device in test_devices() {
+                let decoder = D::from_hf_hub(model_name, model_revision, &device)
+                    .whatever_context("Cannot load decoder")?;
 
-            let (input, mask) = sample_transformer_inputs(&device)?;
+                let (input, mask) = sample_transformer_inputs(&device)?;
 
-            let mut cache = KeyValueCache::cache();
-            let attention_mask = AttentionMask::new(
-                mask.bool_mask()
-                    .narrow(1, 0, 7)
-                    .whatever_context("Cannot slice attention mask")?,
-            )
-            .whatever_context("Cannot build attention mask")?;
-
-            decoder
-                .forward_t(
-                    &input
+                let mut cache = KeyValueCache::cache();
+                let attention_mask = AttentionMask::new(
+                    mask.bool_mask()
                         .narrow(1, 0, 7)
-                        .whatever_context("Cannot slice input")?,
-                    &attention_mask,
-                    &mut cache,
-                    None,
-                    false,
+                        .whatever_context("Cannot slice attention mask")?,
                 )
-                .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))?;
+                .whatever_context("Cannot build attention mask")?;
 
-            let attention_mask = attention_mask
-                .extend(
-                    &AttentionMask::new(
-                        mask.bool_mask()
-                            .narrow(1, 7, 1)
-                            .whatever_context("Cannot slice attention mask")?,
+                with_sdpa_implementation(*sdpa_impl, || {
+                    decoder
+                        .forward_t(
+                            &input
+                                .narrow(1, 0, 7)
+                                .whatever_context("Cannot slice input")?,
+                            &attention_mask,
+                            &mut cache,
+                            None,
+                            false,
+                        )
+                        .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))
+                })?;
+
+                let query_mask = mask
+                    .bool_mask()
+                    .narrow(1, 7, 1)
+                    .whatever_context("Cannot slice attention mask")?;
+
+                let attention_mask = attention_mask
+                    .extend(
+                        &AttentionMask::new(query_mask.clone())
+                            .whatever_context("Cannot build attention mask")?,
                     )
-                    .whatever_context("Cannot build attention mask")?,
-                )
-                .whatever_context("Cannot extend attention mask")?;
+                    .whatever_context("Cannot extend attention mask")?;
 
-            let output = decoder
-                .forward_t(
-                    &input
-                        .narrow(1, 7, 1)
-                        .whatever_context("Cannot slice input")?,
-                    &attention_mask,
-                    &mut cache,
-                    None,
-                    false,
-                )
-                .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))?;
+                let output = with_sdpa_implementation(*sdpa_impl, || {
+                    decoder
+                        .forward_t(
+                            &input
+                                .narrow(1, 7, 1)
+                                .whatever_context("Cannot slice input")?,
+                            &attention_mask,
+                            &mut cache,
+                            None,
+                            false,
+                        )
+                        .map_err(|e| Whatever::with_source(e, "Cannot decode input".to_string()))
+                })?;
 
-            ensure_whatever!(
-                !output.layer_outputs().is_empty(),
-                "Model did not have any outputs"
-            );
-            let last_output = output.layer_outputs().last().unwrap();
+                ensure_whatever!(
+                    !output.layer_outputs().is_empty(),
+                    "Model did not have any outputs"
+                );
+                let last_output = output.layer_outputs().last().unwrap();
+                let last_output = query_mask
+                    .unsqueeze(candle_core::D::Minus1)
+                    .and_then(|mask| mask.to_dtype(last_output.dtype()))
+                    .and_then(|mask| mask.broadcast_as(last_output.shape()))
+                    .and_then(|mask| last_output * mask)
+                    .whatever_context("Cannot mask out logits")?;
 
-            assert_tensor_eq!(
-                last_output
-                    .pseudo_random_reduction()
-                    .whatever_context("Cannot apply reduction using random vector")?,
-                test_tensor.view(),
-                epsilon = 1e-4,
-            );
+                assert_tensor_eq!(
+                    last_output
+                        .pseudo_random_reduction()
+                        .whatever_context("Cannot apply reduction using random vector")?,
+                    test_tensor.view(),
+                    epsilon = relative.epsilon,
+                    max_relative = relative.max_relative,
+                );
+            }
         }
 
         Ok(())


### PR DESCRIPTION
This change adds support for flash attention. Flash attention can be selected using the new `with_attention_impl` wrapper. We fall back to the default implementation when the requirements are not fulfilled.

While at it, also rename all types that start with `ScaledDotProductAttention` to `SDPA`.